### PR TITLE
x86-64 musl builds on Alpine 3.10

### DIFF
--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -1,12 +1,16 @@
-FROM debian:stretch
+FROM alpine:3.10
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends nettle-dev musl-tools \
-        make file wget netcat-traditional sqlite3 git ca-certificates ssh libcap2-bin dnsutils
+# 1st line: Packages needed for building
+# 2nd line: Packaged needed by the CI
+# 3rd line: Packages needed for testing
+RUN apk add --no-cache alpine-sdk linux-headers gmp-dev nettle-dev \
+                       openssh-client \
+                       sqlite bash bind-tools libcap shadow
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
-    tar -xzf ghr_*_linux_amd64.tar.gz && \
+    tar -xzf ghr_*_linux_amd64.tar.gz && rm ghr_*_linux_amd64.tar.gz && \
     mv ghr_*_linux_amd64/ghr /usr/bin/ghr
 
-ENV CC musl-gcc
+ENV CC gcc
+ENV STATIC true


### PR DESCRIPTION
Change back to Alpine for musl builds. 

Uses 3.10 pinned with gcc version 8.3.