### PR TITLE
Add curl as dependency to build-FTL containers

### DIFF
--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -4,7 +4,7 @@ RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends nettle-dev:i386 gcc gcc-multilib \
         make file wget netcat-traditional sqlite3 git ca-certificates ssh libcap-dev:i386 \
-        dnsutils libcap2-bin && rm -rf /var/lib/apt/lists/*
+        dnsutils libcap2-bin curl && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.10
 # 3rd line: Packages needed for testing
 RUN apk add --no-cache alpine-sdk linux-headers gmp-dev nettle-dev \
                        openssh-client \
-                       sqlite bash bind-tools libcap shadow
+                       sqlite bash bind-tools libcap shadow curl
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch
 RUN apt-get update && \
     apt-get install -y --no-install-recommends nettle-dev gcc libc-dev \
         make file wget netcat-traditional sqlite3 git ca-certificates ssh libcap-dev \
-        dnsutils libcap2-bin && rm -rf /var/lib/apt/lists/*
+        dnsutils libcap2-bin curl && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \


### PR DESCRIPTION
`curl` is needed by the all HTTP API tests in branch `new/http`.