### PR TITLE
Preserve the base 'debian:stretch-slim' image reference

### DIFF
--- a/debian-base/Dockerfile
+++ b/debian-base/Dockerfile
@@ -1,19 +1,16 @@
-FROM debian:stretch-slim
+FROM debian:stretch-slim as pam_debians
 COPY create_pam_debians.sh /usr/local/bin/
 RUN bash -ex create_pam_debians.sh
 
-FROM debian:stretch-slim
+FROM debian:stretch-slim as local_pam_repo
 WORKDIR /usr/local/repos/pam
-COPY --from=0 /tmp/*.deb ./
+COPY --from=pam_debians /tmp/*.deb ./
 COPY create_local_pam_repo.sh /usr/local/bin
 RUN bash -ex create_local_pam_repo.sh
 
 FROM debian:stretch-slim
-COPY --from=0 /tmp/*.deb /
-COPY --from=1 /etc/apt/ /etc/apt/
-COPY --from=1 /usr/local/repos/pam /usr/local/repos/pam
+COPY --from=pam_debians /tmp/*.deb /
+COPY --from=local_pam_repo /etc/apt/ /etc/apt/
+COPY --from=local_pam_repo /usr/local/repos/pam /usr/local/repos/pam
 COPY setup.sh /usr/local/bin/
 RUN bash -ex setup.sh && rm /usr/local/bin/setup.sh
-
-FROM scratch
-COPY --from=2 / /


### PR DESCRIPTION
Preserve the base `debian:stretch-slim` image reference at the cost of 4MB uncompressed.

Per discussion on #2, copying all of the files onto a scratch image does reduce overall image size by 4mb. However, it doubles the amount of disc space used on systems that already have the `debian:stretch-slim` base image, as there are no longer any shared layers. This pull request reconciles `pihole/debian-base:latest` with `debian:stretch-slim` - reducing overall system space through shared layers.

Also, name the stages so its a little clearer what stage files are being copied from.

See: https://github.com/pi-hole/docker-base-images/pull/2#discussion_r384229125