### PR TITLE
Branch-based tagging with weekly builds.

### DIFF
--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -1,33 +1,39 @@
 name: Image Builds
-
 on:
+  pull_request:
   push:
   schedule:
-    # 2:30am UTC every Sunday, has no particular meaning
+    # 2:30am UTC every Sunday, has no particular significance
     - cron: '30 2 * * 0'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        TARGET:
+          - debian-base
+          - ftl-build_aarch64
+          - ftl-build_arm
+          - ftl-build_arm-qemu
+          - ftl-build_armhf
+          - ftl-build_x86_32
+          - ftl-build_x86_64
+          - ftl-build_x86_64-musl
+    env:
+      TARGET: ${{matrix.TARGET}}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Install docker-compose 1.25.4 (`ubuntu-latest` currently has 1.22)
-        run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" \
-                    -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Enable QEMU
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - name: Build Images
         run: |
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset
-          docker-compose pull
-          docker-compose build --pull --parallel
-
-      - name: Docker login
-        run: sudo docker login --username=${{ secrets.DOCKERHUB_USER }} --password=${{ secrets.DOCKERHUB_PASS }}
-
+          echo "Building ${TARGET}"
+          docker-compose build --pull ${TARGET}
       - name: Tag and push all images
-        run: ./tag-and-push.sh
+        if: github.event_name != 'pull_request'
+        run: |
+          docker login --username=${{ secrets.DOCKERHUB_USER }} --password=${{ secrets.DOCKERHUB_PASS }}
+          ./tag-and-push.sh ${TARGET}

--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -1,0 +1,33 @@
+name: Image Builds
+
+on:
+  push:
+  schedule:
+    # 2:30am UTC every Sunday, has no particular meaning
+    - cron: '30 2 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install docker-compose 1.25.4 (`ubuntu-latest` currently has 1.22)
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" \
+                    -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
+      - name: Build Images
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset
+          docker-compose pull
+          docker-compose build --pull --parallel
+
+      - name: Docker login
+        run: sudo docker login --username=${{ secrets.DOCKERHUB_USER }} --password=${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Tag and push all images
+        run: ./tag-and-push.sh

--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 # pihole/docker-base-images
 
+![Image Builds](https://github.com/pi-hole/docker-base-images/workflows/Image%20Builds/badge.svg)
+
 Docker images used by other processes within pihole
 
-## What is here?
+## Debian Base [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/debian-base)](https://hub.docker.com/r/pihole/debian-base)
 
-- debian-base: The pihole/docker-pi-hole aka docker image `pihole/pihole` uses this for x86 architecture's base for synolgoy compatiblity
-  - TODO: upgrade to buster and perhaps we don't even need to disable auditd anymore? Needs investigation
-- ftl-build: All of the images used by the pihole/FTL repo to build the contents of that repo
+The pihole/docker-pi-hole aka docker image `pihole/pihole` uses this for x86 architecture's base for synolgoy compatibility
 
-## How does it get uploaded
+Tag Patterns:
+* The standard `latest` tag, which is always in sync with the `master` branch
+* Version tags, such as `v1.1`. Version tags are for a specific release of Dockerfile, however there are still regular builds to pull in changes from the base Debian layers, such as security updates.
+* Branch based tags. These are always in sync with the branch matching the tag name and should only be used for testing and development purposes
 
-CircleCI magic.
+## FTL Images [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/ftl-build)](https://hub.docker.com/r/pihole/ftl-build)
 
+All of the images used by the pihole/FTL repo to build the contents of that repo
+
+Tag Patterns:
+* Architecture tags, such as `x86_64` and `arm`. These are always the latest builds for the given architecture type
+* Version tags with architecture, such as `v1.1-x86_64` and `v1.1-arm`. Version tags are for a specific release of Dockerfiles, however there are still regular builds to pull in changes from the base Debian layers, such as security updates.
+* Branch based tags. These are always in sync with the branch matching the tag name and should only be used for testing and development purposes
+
+## How does it get uploaded?
+
+* GitHub Actions:
+    * Every `push` event triggers a build
+    * Schedule: 2:30am UTC every Sunday

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,42 @@
+version: '3.7'
+
+services:
+  debian-base:
+    image: pihole/debian-base:latest
+    build:
+      context: debian-base
+
+  ftl-build_aarch64:
+    image: pihole/ftl-build:aarch64
+    build:
+      context: ftl-build/aarch64
+
+  ftl-build_arm:
+    image: pihole/ftl-build:arm
+    build:
+      context: ftl-build/arm
+
+  ftl-build_arm-qemu:
+    image: pihole/ftl-build:arm-qemu
+    build:
+      context: ftl-build/arm-qemu
+
+  ftl-build_armhf:
+    image: pihole/ftl-build:armhf
+    build:
+      context: ftl-build/arm-qemu
+
+  ftl-build_x86_32:
+    image: pihole/ftl-build:x86_32
+    build:
+      context: ftl-build/x86_32
+
+  ftl-build_x86_64:
+    image: pihole/ftl-build:x86_64
+    build:
+      context: ftl-build/x86_64
+
+  ftl-build_x86_64-musl:
+    image: pihole/ftl-build:x86_64-musl
+    build:
+      context: ftl-build/x86_64-musl

--- a/ftl-build/arm-qemu/Dockerfile
+++ b/ftl-build/arm-qemu/Dockerfile
@@ -2,7 +2,7 @@ FROM multiarch/debian-debootstrap:armel-stretch-slim
 
 ARG nettleversion=3.4
 
-RUN apt-get update \ 
+RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         build-essential \
         ca-certificates \
@@ -15,7 +15,7 @@ RUN apt-get update \
         m4 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://ftp.gnu.org/gnu/nettle/nettle-${nettleversion}.tar.gz  | tar -xz \
+RUN curl -sSL https://ftp.gnu.org/gnu/nettle/nettle-${nettleversion}.tar.gz  | tar -xz \
     && cd nettle-${nettleversion} \
     && ./configure \
     && make -j $(nproc) \

--- a/tag-and-push.sh
+++ b/tag-and-push.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -ex
+
+function main() {
+  current_git_tag=$(git describe --tags --exact-match || true)
+  current_branch=$(git rev-parse --abbrev-ref HEAD | sed "s/\//-/g")
+
+  # Push debian tags
+  tag_and_push "pihole/debian-base" "latest" "${current_git_tag}"
+  branch_based_tag=$(build_debian_branch_tag "${current_git_tag}")
+  tag_and_push "pihole/debian-base" "latest" "${branch_based_tag}"
+
+  # Push ftl-build tags
+  for flavor in "aarch64" "arm" "arm-qemu" "armhf" "x86_32" "x86_64" "x86_64-musl"; do
+    branch_based_tag=$(build_ftl_branch_tag "${flavor}" "${current_branch}")
+    tag_and_push "pihole/ftl-build" "${flavor}" "${branch_based_tag}"
+
+    git_tag_based_tag=$(build_ftl_git_tag_tag "${flavor}" "${current_git_tag}")
+    tag_and_push "pihole/ftl-build" "${flavor}" "${git_tag_based_tag}"
+  done
+}
+
+# Tag and push a docker image if the given tag isn't empty
+function tag_and_push() {
+  image="${1}"
+  local_tag="${2}"
+  target_tag="${3}"
+  if [ -n "${target_tag}" ]; then
+    docker tag "${image}:${local_tag}" "${image}:${target_tag}"
+    docker push "${image}:${target_tag}"
+  fi
+}
+
+# Build a docker tag based on the git branch.
+# examples:
+#     dev branch: dev
+#     master branch: latest
+function build_debian_branch_tag() {
+  branch="${1}"
+
+  if [ "${branch}" = "master" ]; then
+    echo "latest"
+  else
+    echo "${branch}"
+  fi
+}
+
+# Build a docker tag based on the architecture flavor and git branch.
+# examples:
+#     dev branch: dev-x86_64-musl
+#     master branch: x86_64-musl
+function build_ftl_branch_tag() {
+  flavor="${1}"
+  branch="${2}"
+
+  if [ "${branch}" = "master" ]; then
+    echo "${flavor}"
+  else
+    echo "${branch}-${flavor}"
+  fi
+}
+
+# Build a docker tag based on the FTL architecture flavor and git tag.
+# examples:
+#     tag v1.1: "v1.1-x86_64-musl"
+#     no tag: ""
+function build_ftl_git_tag_tag() {
+  flavor="${1}"
+  git_tag="${2}"
+
+  if [ -n "${git_tag}" ]; then
+    echo "${current_git_tag}-${flavor}"
+  fi
+}
+
+main

--- a/tag-and-push.sh
+++ b/tag-and-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 function main() {
   current_git_tag=$(git describe --tags --exact-match || true)
@@ -6,7 +6,7 @@ function main() {
 
   # Push debian tags
   tag_and_push "pihole/debian-base" "latest" "${current_git_tag}"
-  branch_based_tag=$(build_debian_branch_tag "${current_git_tag}")
+  branch_based_tag=$(build_debian_branch_tag "${current_branch}")
   tag_and_push "pihole/debian-base" "latest" "${branch_based_tag}"
 
   # Push ftl-build tags
@@ -25,6 +25,7 @@ function tag_and_push() {
   local_tag="${2}"
   target_tag="${3}"
   if [ -n "${target_tag}" ]; then
+    echo "Tagging ${image}:${target_tag}"
     docker tag "${image}:${local_tag}" "${image}:${target_tag}"
     docker push "${image}:${target_tag}"
   fi
@@ -68,7 +69,7 @@ function build_ftl_git_tag_tag() {
   git_tag="${2}"
 
   if [ -n "${git_tag}" ]; then
-    echo "${current_git_tag}-${flavor}"
+    echo "${git_tag}-${flavor}"
   fi
 }
 


### PR DESCRIPTION
## Description
Enables smart docker tagging based on git branches and git tags. Builds are ran automatically on 'push' events. The docker tags will be based on the branch that was pushed. For example, if 'master' was pushed, then the standard tags will get created such as 'latest' and 'x86_64'. If there is a tag on HEAD, then it will also generate the version-based tags, like 'v1.1-x86_64' and 'v1.1'.  The builds are also ran weekly for the master branch, pulling in any security updates from the base layers.

Other changes:
* Improved README.md with more details about the project and links to docker hub
* Added docker-compose.yaml for easier image building
* Added failure flags to curl to ensure it exits on error

## Github Actions

I've taken a major liberty with this pull request and introduced Github Actions. I realize that it is currently using CircleCI - so perhaps this is an unwelcome aspect of the pull request. If no one on the PiHole team wants Github Actions, then I believe the majority of this pull request would still be useful, but updates would be required. Here is my logic in using GitHub actions:

* Github Actions live within Github. So anyone looking at the code here should be able to easily find the actions associated with the repo. Where are the Circle CI Builds? The readme says its magic. I'm not being serious, I'm sure I can find them if I spent the time to dig for them - but that's kinda my point here. Its really nice (IMO) to have the repo and the builds located in the same location.
* Its easy to checkout a repo in Github Actions with an attached HEAD. I do not have any experience with CircleCI, so maybe that is easy too - but I know in Jenkins, CodeBuild, and TravisCI - all the builds are done with a detached head. It doesn't seem like a big deal, but its a pain to find what branch you building when HEAD is detached - since you are not on a branch. A lot of times the build system compensates for this by supplying the branch name as an environment variable, but that's still a pain since its system dependent. I'd rather just get the branch from git - so I can test it locally. /rant
* I don't have Circle CI experience, and I wasn't in the mood to learn it. This is a terrible reason, and works the same way against Github Actions, but I'm being honest that this was a factor for me- especially given my above explanation about detached heads. If Github Actions is a blocker on this pull request, then someone else will need to figure all that out.

## Motivation and Context

* Regularly pull in updates from base layers, such as security updates
    * [Update PHP Version (7.0 -> 7.2 or 7.3) and Debian (9.5 -> 9.9)](https://github.com/pi-hole/docker-pi-hole/issues/474#issuecomment-504776884)
    * [increase docker image build frequency](https://github.com/pi-hole/docker-pi-hole/issues/558)
* Laying the base work for building multiple flavors of Debian (buster & stretch). I believe having this logic in place is an essential first step before multiple flavors of Debian can be supported. In fact, if this pull request is accepted, then I intend to follow up with another pull request to implement buster builds (along side of stretch).
* Having branch-based tagging will allow a 'dev' branch to get updates faster without affecting down-stream projects

## How Has This Been Tested?

I setup the Actions on my own repo. However, I was unable to test `docker push` commands for obvious reasons. Also, some of the links in this pull request are essentially dead links until it gets merged into master. An example is the 'Build Status' badge added to the README.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Further Actions Needed:

If everyone is on board with Github Actions, then two variables need to be added to the repo settings, under 'Secrets':
1. `DOCKERHUB_USER`
2. `DOCKERHUB_PAS`

This will enable the builds to push the images. I designed the action specifically to be able to get through the entire build phase before trying to login, this way you can accept the pull request and test out the builds before giving it full `push` permissions.

**Finally, thank you for your time reviewing this pull request. I understand that pull request review is a lot of work- especially for something that no one asked for. This is not a small change, so Thank you.**