### PR TITLE
Download pre-compiled libidn2 from ftl.pi-hole.net

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -22,6 +22,7 @@ RUN dpkg --add-architecture arm64 \
         ssh \
         sqlite3 \
         wget \
+        binutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/arm-qemu/Dockerfile
+++ b/ftl-build/arm-qemu/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
         libgmp-dev \
         libidn11-dev \
         m4 \
+        binutils \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://ftp.gnu.org/gnu/nettle/nettle-${nettleversion}.tar.gz  | tar -xz \

--- a/ftl-build/arm/Dockerfile
+++ b/ftl-build/arm/Dockerfile
@@ -19,18 +19,22 @@ RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
     wget ftl.pi-hole.net/libraries/libcap.so.2.25 -O /usr/local/lib/libcap.so && \
     wget ftl.pi-hole.net/libraries/libidn2.so.0.1.4 -O  /usr/local/lib/libidn2.so
 
-RUN dpkg --add-architecture armhf && \
+RUN dpkg --add-architecture armel && \
     apt-get update && \
     apt-get install -y --no-install-recommends make file netcat-traditional ssh \
-        nettle-dev:armhf libcap-dev sqlite3 libcap2-bin dnsutils libidn11-dev:armhf
+        nettle-dev:armel libcap-dev sqlite3 libcap2-bin dnsutils libidn11-dev:armel \
+        libgmp-dev:armel
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
     tar -xzf ghr_*_linux_amd64.tar.gz && \
     mv ghr_*_linux_amd64/ghr /usr/bin/ghr
 
-# We use the libnettle and libidn headers from the armhf packages, however, we
+# We use the libnettle and libidn headers from the armel packages, however, we
 # use the armv6 compatible libraries we built on a Raspberry Pi Zero and
 # uploaded them to ftl.pi-hole.net. Note that we do NOT include
 # -L/usr/lib/arm-linux-gnueabihf here as this would result in incompatible binaries
-ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf -L/usr/local/lib"
+ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabi -L/usr/local/lib"
+
+# Uncomment the following line to test-compile FTL master during docker container development
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && make -j $(nproc)

--- a/ftl-build/arm/Dockerfile
+++ b/ftl-build/arm/Dockerfile
@@ -1,8 +1,32 @@
 FROM debian:stretch
 
 # Packages required to install compiler and libraries
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget git ca-certificates
+RUN dpkg --add-architecture armel \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    wget \
+    git \
+    ca-certificates \
+    curl \
+    make \
+    file \
+    netcat-traditional \
+    ssh \
+    sqlite3 \
+    dnsutils \
+    binutils \
+    nettle-dev:armel \
+    libcap-dev:armel \
+    libgmp-dev:armel \
+    && rm -rf /var/lib/apt/lists/*
+
+# ghr 0.13.0 2019-09-16
+ARG ghrversion=0.13.0
+
+# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
+RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
+    tar --strip-components=1 -C /usr/bin/ -xz \
+    ghr_v${ghrversion}_linux_amd64/ghr
 
 # Use Raspbian's GCC
 # This command was taken from https://github.com/dockcross/dockcross/blob/master/linux-armv6/Dockerfile
@@ -13,28 +37,22 @@ RUN mkdir rpi_tools && cd rpi_tools && git init && git remote add origin https:/
     git pull --depth=1 origin master && \
     cp -a arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/* /usr/ && rm -rf ../rpi_tools
 
+# Download procompiled armv6 libraries
 RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
     wget ftl.pi-hole.net/libraries/libnettle.a -O /usr/local/lib/libnettle.a && \
-    wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a && \
-    wget ftl.pi-hole.net/libraries/libcap.so.2.25 -O /usr/local/lib/libcap.so && \
-    wget ftl.pi-hole.net/libraries/libidn2.so.0.1.4 -O  /usr/local/lib/libidn2.so
-
-RUN dpkg --add-architecture armel && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends make file netcat-traditional ssh \
-        nettle-dev:armel libcap-dev sqlite3 libcap2-bin dnsutils libidn11-dev:armel \
-        libgmp-dev:armel
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
-    tar -xzf ghr_*_linux_amd64.tar.gz && \
-    mv ghr_*_linux_amd64/ghr /usr/bin/ghr
+    wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a
 
 # We use the libnettle and libidn headers from the armel packages, however, we
 # use the armv6 compatible libraries we built on a Raspberry Pi Zero and
 # uploaded them to ftl.pi-hole.net. Note that we do NOT include
 # -L/usr/lib/arm-linux-gnueabihf here as this would result in incompatible binaries
-ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabi -L/usr/local/lib"
+ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabi -I/usr/local/include -L/usr/local/lib"
+
+# Download and cross-compile libidn, we prevent the examples from being built as they will not
+# run on the x86_64 host and lead to errors
+RUN wget https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz && tar -xzf libidn-1.35.tar.gz && \
+    cd libidn-1.35 && ./configure --host=armv6-linux-gnueabi --disable-shared --disable-doc --without-examples && \
+    make -j $(nproc) install
 
 # Uncomment the following line to test-compile FTL master during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && make -j $(nproc)
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development && make -j $(nproc) && readelf -A ./pihole-FTL

--- a/ftl-build/arm/Dockerfile
+++ b/ftl-build/arm/Dockerfile
@@ -16,7 +16,8 @@ RUN mkdir rpi_tools && cd rpi_tools && git init && git remote add origin https:/
 RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
     wget ftl.pi-hole.net/libraries/libnettle.a -O /usr/local/lib/libnettle.a && \
     wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a && \
-    wget ftl.pi-hole.net/libraries/libcap.so.2.25 -O /usr/local/lib/libcap.so
+    wget ftl.pi-hole.net/libraries/libcap.so.2.25 -O /usr/local/lib/libcap.so && \
+    wget ftl.pi-hole.net/libraries/libidn2.so.0.1.4 -O  /usr/local/lib/libidn2.so
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
@@ -28,5 +29,8 @@ RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_lin
     tar -xzf ghr_*_linux_amd64.tar.gz && \
     mv ghr_*_linux_amd64/ghr /usr/bin/ghr
 
-# Allow libnettle and libidn to be used, because this GCC doesn't have all the right header and library directories
-ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf -L/usr/lib/arm-linux-gnueabihf -L/usr/local/lib"
+# We use the libnettle and libidn headers from the armhf packages, however, we
+# use the armv6 compatible libraries we built on a Raspberry Pi Zero and
+# uploaded them to ftl.pi-hole.net. Note that we do NOT include
+# -L/usr/lib/arm-linux-gnueabihf here as this would result in incompatible binaries
+ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf -L/usr/local/lib"

--- a/ftl-build/armhf/Dockerfile
+++ b/ftl-build/armhf/Dockerfile
@@ -22,6 +22,7 @@ RUN dpkg --add-architecture armhf \
         ssh \
         sqlite3 \
         wget \
+        binutils \
     && rm -rf /var/lib/apt/lists/*
     
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -22,6 +22,7 @@ RUN dpkg --add-architecture i386 \
         sqlite3 \
         ssh \
         wget \
+        binutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
         nettle-dev \
         openssh-client \
         shadow \
-        sqlite
+        sqlite \
+        binutils
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
         sqlite3 \
         ssh \
         wget \
+        binutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr


### PR DESCRIPTION
The `ftl-build:v1.1/arm` container is currently linking the `armhf` variant of `libidn2` into the FTL binary. This library, however, contains armv7 instructions, effectively increasing the architectural dependencies. This can be verified with `readelf -A ./pihole-FTL` showing armv**7**:
```plain
$ readelf -A ./pihole-FTL | grep -E "(CPU|FP)_arch"
  Tag_CPU_arch: v7
  Tag_FP_arch: VFPv3-D16
```

This PR uses a library pre-compiled on a Raspberry Pi Zero, which is what we're doing for other libraries as well. The result is now as we'd expect it to be (armv**6**):
```plain
$ readelf -A ./pihole-FTL | grep -E "(CPU|FP)_arch"
  Tag_CPU_arch: v6
  Tag_FP_arch: VFPv2
```