### PR TITLE
Only allow special branches to get official tagged & pushed images

### DIFF
--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -2,6 +2,11 @@ name: Image Builds
 on:
   pull_request:
   push:
+    branches:
+      - master
+      # add any branch names here that should build on push.
+      # the branch name will be included in the resulting docker tag.
+      - dev
   schedule:
     # 2:30am UTC every Sunday, has no particular significance
     - cron: '30 2 * * 0'


### PR DESCRIPTION
Only allow special branches to get official tagged & pushed images. Currently just 'master' and 'dev'. Except for the 'master' branch, the branch name will be part of the resulting tag name. For example, `pihole/debian-base:dev` and `pihole/ftl-build:dev-arm`