### PR TITLE
Added tagging logic for debian-base to support both Stretch and Buster build tags.

### DIFF
--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -20,7 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         TARGET:
-          - debian-base
+          - debian-base-stretch
+          - debian-base-buster
           - web-build
           - ftl-build_aarch64
           - ftl-build_arm

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pihole/docker-base-images
 
-![Image Builds](https://github.com/pi-hole/docker-base-images/workflows/Image%20Builds/badge.svg)
+[![Image Builds](https://github.com/pi-hole/docker-base-images/workflows/Image%20Builds/badge.svg)](https://github.com/pi-hole/docker-base-images/actions)
 
-Docker images used by other processes within pihole
+Docker images used by other processes within pihole.
 
 ## Debian Base [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/debian-base)](https://hub.docker.com/r/pihole/debian-base)
 
@@ -11,16 +11,21 @@ The pihole/docker-pi-hole aka docker image `pihole/pihole` uses this for x86 arc
 Tag Patterns:
 * The standard `latest` tag, which is always in sync with the `master` branch
 * Version tags, such as `v1.1`. Version tags are for a specific release of Dockerfile, however there are still regular builds to pull in changes from the base Debian layers, such as security updates.
-* Branch based tags. These are always in sync with the branch matching the tag name and should only be used for testing and development purposes
+* Branch based tags. These are always in sync with the branch matching the tag name and should only be used for testing and development purposes.
+* Debian based tags: `buster`, `stretch`, `v1.1-buster`, `v1.1-stretch`, `dev-buster`, `dev-stretch`.
 
 ## FTL Images [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/ftl-build)](https://hub.docker.com/r/pihole/ftl-build)
 
-All of the images used by the pihole/FTL repo to build the contents of that repo
+All the images used by the pihole/FTL repo to build the contents of that repo
 
 Tag Patterns:
 * Architecture tags, such as `x86_64` and `arm`. These are always the latest builds for the given architecture type
 * Version tags with architecture, such as `v1.1-x86_64` and `v1.1-arm`. Version tags are for a specific release of Dockerfiles, however there are still regular builds to pull in changes from the base Debian layers, such as security updates.
-* Branch based tags. These are always in sync with the branch matching the tag name and should only be used for testing and development purposes
+* Branch based tags. These are always in sync with the branch matching the tag name and should only be used for testing and development purposes.
+
+## Web Build Image [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/web-build)](https://hub.docker.com/r/pihole/web-build)
+
+Build image used by the [web repo](https://github.com/pi-hole/web)
 
 ## How does it get uploaded?
 

--- a/debian-base/Dockerfile
+++ b/debian-base/Dockerfile
@@ -1,14 +1,15 @@
-FROM debian:stretch-slim as pam_debians
+ARG DEBIAN_VERSION=buster
+FROM debian:${DEBIAN_VERSION}-slim as pam_debians
 COPY create_pam_debians.sh /usr/local/bin/
 RUN bash -ex create_pam_debians.sh
 
-FROM debian:stretch-slim as local_pam_repo
+FROM debian:${DEBIAN_VERSION}-slim as local_pam_repo
 WORKDIR /usr/local/repos/pam
 COPY --from=pam_debians /tmp/*.deb ./
 COPY create_local_pam_repo.sh /usr/local/bin
 RUN bash -ex create_local_pam_repo.sh
 
-FROM debian:stretch-slim
+FROM debian:${DEBIAN_VERSION}-slim
 COPY --from=pam_debians /tmp/*.deb /
 COPY --from=local_pam_repo /etc/apt/ /etc/apt/
 COPY --from=local_pam_repo /usr/local/repos/pam /usr/local/repos/pam

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,19 @@
 version: '3.7'
 
 services:
-  debian-base:
-    image: pihole/debian-base:latest
+  debian-base-stretch:
+    image: pihole/debian-base:stretch
     build:
       context: debian-base
+      args:
+        DEBIAN_VERSION: stretch
+
+  debian-base-buster:
+    image: pihole/debian-base:buster
+    build:
+      context: debian-base
+      args:
+        DEBIAN_VERSION: buster
 
   web-build:
     image: pihole/web-build:latest

--- a/tag-and-push.sh
+++ b/tag-and-push.sh
@@ -1,42 +1,68 @@
 #!/bin/bash -e
 
+# Usage: ./tag-and-push.sh ${docker-compose-service-name}
+# examples:
+#     ./tag-and-push.sh debian-base-buster
+#     ./tag-and-push.sh ftl-build_aarch64
+#
+# DRY_RUN=true to skip pushing images
+#
 function main() {
   target="${1}"
   current_git_tag=$(git describe --tags --exact-match 2> /dev/null || true)
   current_branch=$(git rev-parse --abbrev-ref HEAD | sed "s/\//-/g")
 
-  # Push debian and web-build tags
-  if [ "${target}" = "debian-base" ] || [ "${target}" = "web-build" ]; then
-      tag_and_push "pihole/${target}" "latest" "${current_git_tag}"
-      branch_based_tag=$(build_branch_tag "${current_branch}")
-      tag_and_push "pihole/${target}" "latest" "${branch_based_tag}"
+  # Push debian tags
+  if [[ "${target:0:11}" = "debian-base" ]]; then
+    flavor=${target:12:$$}
+    # TODO set buster as the primary version for `latest` and tag-based builds
+    primary_debian_version="stretch"
+    branch_based_tag=$(build_branch_tag "${current_branch}")
+    flavored_git_tag_based_tag=$(build_flavored_git_tag_tag "${flavor}" "${current_git_tag}")
+    flavored_branch_name=$(build_flavored_branch_name "${current_branch}" "${flavor}")
+
+    if [[ "${flavor}" = "${primary_debian_version}" ]]; then
+      tag_and_push "pihole/debian-base" "${flavor}" "${current_git_tag}"
+      tag_and_push "pihole/debian-base" "${flavor}" "${flavored_git_tag_based_tag}"
+      tag_and_push "pihole/debian-base" "${flavor}" "${branch_based_tag}"
+      tag_and_push "pihole/debian-base" "${flavor}" "${flavored_branch_name}"
+    else
+      tag_and_push "pihole/debian-base" "${flavor}" "${flavored_branch_name}"
+      tag_and_push "pihole/debian-base" "${flavor}" "${flavored_git_tag_based_tag}"
+    fi
   fi
 
   # Push web-build node version
-  if [ "${target}" = "web-build" ]; then
-      tag_and_push "pihole/${target}" "latest" "12"
+  if [[ "${target}" = "web-build" ]]; then
+    branch_based_tag=$(build_branch_tag "${current_branch}")
+    tag_and_push "pihole/web-build" "latest" "${current_git_tag}"
+    tag_and_push "pihole/web-build" "latest" "${branch_based_tag}"
+    tag_and_push "pihole/web-build" "latest" "12"
   fi
 
   # Push FTL tags
-  if [ "${target:0:9}" = "ftl-build" ]; then
+  if [[ "${target:0:9}" = "ftl-build" ]]; then
     flavor=${target:10:$$}
     branch_based_tag=$(build_ftl_branch_tag "${flavor}" "${current_branch}")
     tag_and_push "pihole/ftl-build" "${flavor}" "${branch_based_tag}"
 
-    git_tag_based_tag=$(build_ftl_git_tag_tag "${flavor}" "${current_git_tag}")
+    git_tag_based_tag=$(build_flavored_git_tag_tag "${flavor}" "${current_git_tag}")
     tag_and_push "pihole/ftl-build" "${flavor}" "${git_tag_based_tag}"
   fi
 }
 
 # Tag and push a docker image if the given tag isn't empty
+# Set environment var `DRY_RUN=true` to disable docker push.
 function tag_and_push() {
   image="${1}"
   local_tag="${2}"
   target_tag="${3}"
-  if [ -n "${target_tag}" ]; then
-    echo "Tagging ${image}:${target_tag}"
+  if [[ -n "${target_tag}" ]]; then
+    echo "Tagging ${image}:${local_tag} as ${target_tag}"
     docker tag "${image}:${local_tag}" "${image}:${target_tag}"
-    docker push "${image}:${target_tag}"
+    if [[ "${DRY_RUN}" != "true" ]]; then
+        docker push "${image}:${target_tag}"
+    fi
   fi
 }
 
@@ -47,10 +73,21 @@ function tag_and_push() {
 function build_branch_tag() {
   branch="${1}"
 
-  if [ "${branch}" = "master" ]; then
+  if [[ "${branch}" = "master" ]]; then
     echo "latest"
   else
     echo "${branch}"
+  fi
+}
+
+function build_flavored_branch_name() {
+  branch="${1}"
+  flavor="${2}"
+
+  if [[ "${branch}" = "master" ]]; then
+    echo "${flavor}"
+  else
+    echo "${branch}-${flavor}"
   fi
 }
 
@@ -62,22 +99,23 @@ function build_ftl_branch_tag() {
   flavor="${1}"
   branch="${2}"
 
-  if [ "${branch}" = "master" ]; then
+  if [[ "${branch}" = "master" ]]; then
     echo "${flavor}"
   else
     echo "${branch}-${flavor}"
   fi
 }
 
-# Build a docker tag based on the FTL architecture flavor and git tag.
+# Build a docker tag based on the FTL-architecture/debian flavor and git tag.
 # examples:
 #     tag v1.1: "v1.1-x86_64-musl"
+#     tag v1.1: "v1.1-buster"
 #     no tag: ""
-function build_ftl_git_tag_tag() {
+function build_flavored_git_tag_tag() {
   flavor="${1}"
   git_tag="${2}"
 
-  if [ -n "${git_tag}" ]; then
+  if [[ -n "${git_tag}" ]]; then
     echo "${git_tag}-${flavor}"
   fi
 }


### PR DESCRIPTION
Added tagging logic for `debian-base` images to support both Stretch and Buster build tags.

1. These changes were only made to the `debian-base` image as the downstream `docker-pi-hole` would be affected if the image were immediately cut over to Buster.
2. I have no idea how the FTL will be affected from Buster images, so I just didn't touch them. As far as I know, #14 is valid for the FTL images without needing new tagging logic. Someone else needs to figure that out.
3. Stretch is still the default Debian flavor for the resulting `debian-base:lastest` image.
4. Some tag examples:
    * `debian-base:latest` (on master - stretch for now)
    * `debian-base:stretch` (on master)
    * `debian-base:buster` (on master)
    * `debian-base:{tag}` (branch doesn't matter - stretch for now)
    * `debian-base:{tag}-stretch` (branch doesn't matter)
    * `debian-base:{tag}-buster` (branch doesn't matter)
    * `debian-base:{branch}` (stretch for now)
    * `debian-base:{branch}-stretch`
    * `debian-base:{branch}-buster`
5. After downstream is happy with Buster, Buster can be made the default flavor.


Want to test this?
* Clone
* `docker-compose build`
* Wait....
* run `DRY_RUN=true ./tag-and-push.sh {docker-compose service name}` to see what the resulting tags are, example: `DRY_RUN=true ./tag-and-push.sh debian-base-stretch`.
* make tags, switch branches, re-run and see how the tags change.