### PR TITLE
Add libreadline and libtermcap to ftl-build containers

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
 RUN dpkg --add-architecture arm64 \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -24,6 +27,7 @@ RUN dpkg --add-architecture arm64 \
         wget \
         binutils \
         cmake \
+        libc6-dev:arm64 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
@@ -31,4 +35,26 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
     tar --strip-components=1 -C /usr/bin/ -xz \
     ghr_v${ghrversion}_linux_amd64/ghr
 
-ENV CC aarch64-linux-gnu-gcc
+ENV CC aarch64-linux-gnu-gcc -isystem /usr/local/include
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --host=aarch64-linux-gnu --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --host=aarch64-linux-gnu --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Uncomment the following line to test-compile FTL master during docker container development
+#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/arm-qemu/Dockerfile
+++ b/ftl-build/arm-qemu/Dockerfile
@@ -1,6 +1,8 @@
 FROM multiarch/debian-debootstrap:armel-stretch-slim
 
 ARG nettleversion=3.4
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -17,10 +19,32 @@ RUN apt-get update \
         cmake \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSL https://ftp.gnu.org/gnu/nettle/nettle-${nettleversion}.tar.gz  | tar -xz \
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
-    && ./configure \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) \
     && make install \
     && cd .. \
     && rm -r nettle-${nettleversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Uncomment the following line to test-compile FTL master during docker container development
+#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/arm/Dockerfile
+++ b/ftl-build/arm/Dockerfile
@@ -1,5 +1,11 @@
 FROM debian:stretch
 
+# ghr 0.13.0 2019-09-16
+ARG ghrversion=0.13.0
+
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
 # Packages required to install compiler and libraries
 RUN dpkg --add-architecture armel \
     && apt-get update \
@@ -19,10 +25,8 @@ RUN dpkg --add-architecture armel \
     nettle-dev:armel \
     libcap-dev:armel \
     libgmp-dev:armel \
+    libc6-dev:armel \
     && rm -rf /var/lib/apt/lists/*
-
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
@@ -47,13 +51,33 @@ RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
 # use the armv6 compatible libraries we built on a Raspberry Pi Zero and
 # uploaded them to ftl.pi-hole.net. Note that we do NOT include
 # -L/usr/lib/arm-linux-gnueabihf here as this would result in incompatible binaries
-ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabi -I/usr/local/include -L/usr/local/lib"
+ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/include -isystem /usr/include/arm-linux-gnueabi -isystem /usr/local/include -L/usr/local/lib"
+RUN ln -s /usr/arm-linux-gnueabihf/sysroot/usr/lib/libm.so /usr/local/lib/
 
 # Download and cross-compile libidn, we prevent the examples from being built as they will not
 # run on the x86_64 host and lead to errors
-RUN wget https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz && tar -xzf libidn-1.35.tar.gz && \
+RUN curl -sSL https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz | tar -xz && \
     cd libidn-1.35 && ./configure --host=armv6-linux-gnueabi --disable-shared --disable-doc --without-examples && \
     make -j $(nproc) install
 
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
 # Uncomment the following line to test-compile FTL master during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development && make -j $(nproc) && readelf -A ./pihole-FTL
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/armhf/Dockerfile
+++ b/ftl-build/armhf/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
 RUN dpkg --add-architecture armhf \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -24,6 +27,7 @@ RUN dpkg --add-architecture armhf \
         wget \
         binutils \
         cmake \
+        libc6:armhf \
     && rm -rf /var/lib/apt/lists/*
     
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
@@ -31,4 +35,27 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
     tar --strip-components=1 -C /usr/bin/ -xz \
     ghr_v${ghrversion}_linux_amd64/ghr
 
-ENV CC arm-linux-gnueabihf-gcc
+ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/local/include"
+RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --host=arm-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --host=arm-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Uncomment the following line to test-compile FTL master during docker container development
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
 RUN dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -24,6 +27,7 @@ RUN dpkg --add-architecture i386 \
         wget \
         binutils \
         cmake \
+        libc6:i386 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
@@ -32,3 +36,26 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
     ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC "gcc -m32"
+RUN ln -s /usr/lib32/libm.so /usr/local/lib/
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Uncomment the following line to test-compile FTL master during docker container development
+#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.10
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
 RUN apk add --no-cache \
         alpine-sdk \
         bash \
@@ -26,3 +29,25 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
 
 ENV CC gcc
 ENV STATIC true
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Uncomment the following line to test-compile FTL master during docker container development
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates \
@@ -31,3 +34,25 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
     ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC gcc
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Uncomment the following line to test-compile FTL master during docker container development
+#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL


### PR DESCRIPTION
Add `libreadline` and `libtermcap` to `ftl-build` containers in preparation for adding `lua` to FTL.
This revision of the `ftl-build` containers is supposed to be tagged v1.4.