### PR TITLE
Make arm-qemu builds ARMv4T compliant (was ARMv6) to support more devices

### DIFF
--- a/ftl-build/arm-qemu/Dockerfile
+++ b/ftl-build/arm-qemu/Dockerfile
@@ -21,16 +21,16 @@ RUN apt-get update \
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
-    && make -j $(nproc) \
+    && ./configure --host=armv5-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make \
     && make install \
     && cd .. \
     && rm -r nettle-${nettleversion}
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
-    && make -j $(nproc) \
+    && ./configure --host=armv5-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make \
     && make install \
     && ls /usr/local/lib/ \
     && cd .. \
@@ -38,8 +38,8 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
-    && make -j $(nproc) \
+    && ./configure --host=armv5-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Explicitly specify the building host to achieve true ARM Debian compliance with the cross-compiled build. We remove concurrent building of the dependencies as this can lead to compiler segmentation faults on many-core machines with a lot of concurrency in the emulator.

Even though this build only requested ARMv5 compliance, the produce code actually generated a binary that is even ARMv4T complaint:
```
Attribute Section: aeabi
File Attributes
  Tag_CPU_name: "4T"
  Tag_CPU_arch: v4T
  Tag_ARM_ISA_use: Yes
  Tag_THUMB_ISA_use: Thumb-1
  Tag_ABI_PCS_wchar_t: 4
  Tag_ABI_FP_rounding: Needed
  Tag_ABI_FP_denormal: Needed
  Tag_ABI_FP_exceptions: Needed
  Tag_ABI_FP_number_model: IEEE 754
  Tag_ABI_align_needed: 8-byte
  Tag_ABI_enum_size: int
```

Even when this is not the expected outcome, any ARMv5TE processor will be able to run ARMv4T code. And as the compiler generated ARMv4T code while it was allowed to generate ARMv5TE means that, despite the fact that all compiler optimizations are enabled, no ARMv5TE-specific instructions are useful here and the generation of ARMv4T-compliant code is not slower by any means (due to missed optimizations).

The PR updating the FTL builds for ARMv4T-compliance will also address the changed architecture in the tests. This has to come *after* this PR was merged.