### PR TITLE
ftl-build container improvements

### DIFF
--- a/.github/workflows/image-builds.yaml
+++ b/.github/workflows/image-builds.yaml
@@ -28,6 +28,7 @@ jobs:
           - ftl-build_armv5te
           - ftl-build_armv6hf
           - ftl-build_armv7hf
+          - ftl-build_armv8a
           - ftl-build_x86_32
           - ftl-build_x86_64
           - ftl-build_x86_64-musl

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,11 @@ services:
     build:
       context: ftl-build/armv7hf
 
+  ftl-build_armv8a:
+    image: pihole/ftl-build:armv8a
+    build:
+      context: ftl-build/armv8a
+
   ftl-build_x86_32:
     image: pihole/ftl-build:x86_32
     build:

--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
@@ -55,6 +55,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
-#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Uncomment the following line to test-compile FTL development during docker container development
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:buster
 
+# For FTL test compilation
+ARG CIRCLE_JOB="aarch64"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -55,6 +60,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -1,6 +1,11 @@
 # Note that this has to stay at stretch as buster removed ARMv4T compliance
 FROM debian:stretch
 
+# For FTL test compilation
+ARG CIRCLE_JOB="armv4t"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -65,6 +70,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:stretch
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -39,6 +40,13 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
 ENV CC "arm-linux-gnueabi-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/
 
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
+
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
     && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
@@ -57,6 +65,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
+# Uncomment the following line to test-compile FTL development during docker container development
 # RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
 #     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:buster
 
+# For FTL test compilation
+ARG CIRCLE_JOB="armv5te"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -63,6 +68,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:buster
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -18,7 +19,6 @@ RUN dpkg --add-architecture armel \
         libc6-dev-armel-cross \
         libcap-dev:armel \
         libcap2-bin \
-        libidn11-dev:armel \
         make \
         netcat-traditional \
         nettle-dev:armel \
@@ -38,6 +38,13 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
 ENV CC "arm-linux-gnueabi-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/
 
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
+
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
     && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
@@ -56,6 +63,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
+# Uncomment the following line to test-compile FTL development during docker container development
 # RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
 #     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -1,8 +1,10 @@
-FROM debian:buster
+# We cannot use stretch here due to libc-incompatibilities (undefined reference to `fcntl64')
+FROM debian:stretch
 
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -54,11 +56,12 @@ RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
 ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/include -isystem /usr/include/arm-linux-gnueabi -isystem /usr/local/include -L/usr/local/lib"
 RUN ln -s /usr/arm-linux-gnueabihf/sysroot/usr/lib/libm.so /usr/local/lib/
 
-# Download and cross-compile libidn, we prevent the examples from being built as they will not
-# run on the x86_64 host and lead to errors
-RUN curl -sSL https://ftp.gnu.org/gnu/libidn/libidn-1.35.tar.gz | tar -xz && \
-    cd libidn-1.35 && ./configure --host=armv6-linux-gnueabi --disable-shared --disable-doc --without-examples && \
-    make -j $(nproc) install
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
@@ -78,6 +81,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
+# Uncomment the following line to test-compile FTL development during docker container development
 # RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
 #     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -1,6 +1,11 @@
 # We cannot use stretch here due to libc-incompatibilities (undefined reference to `fcntl64')
 FROM debian:stretch
 
+# For FTL test compilation
+ARG CIRCLE_JOB="armv6hf"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -81,6 +86,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:buster
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -18,7 +19,6 @@ RUN dpkg --add-architecture armhf \
         libc6-dev-armhf-cross \
         libcap-dev:armhf \
         libcap2-bin \
-        libidn11-dev:armhf \
         make \
         netcat-traditional \
         nettle-dev:armhf \
@@ -38,9 +38,16 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
 ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/
 
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
+
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
-    && ./configure --host=arm-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv7-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) \
     && make install \
     && ls /usr/local/lib/ \
@@ -49,13 +56,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=arm-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv7-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Uncomment the following line to test-compile FTL development during docker container development
+RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:buster
 
+# For FTL test compilation
+ARG CIRCLE_JOB="armv7hf"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -63,6 +68,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -1,0 +1,79 @@
+FROM debian:buster
+
+# For FTL test compilation
+ARG CIRCLE_JOB="armv8a"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
+# ghr 0.13.0 2019-09-16
+ARG ghrversion=0.13.0
+
+ARG idnversion=1.36
+ARG readlineversion=8.0
+ARG termcapversion=1.3.1
+
+RUN dpkg --add-architecture armhf \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        dnsutils \
+        file \
+        gcc-arm-linux-gnueabihf \
+        git \
+        libc6-dev-armhf-cross \
+        libcap-dev:armhf \
+        libcap2-bin \
+        make \
+        netcat-traditional \
+        nettle-dev:armhf \
+        ssh \
+        sqlite3 \
+        wget \
+        binutils \
+        cmake \
+        libc6:armhf \
+    && rm -rf /var/lib/apt/lists/*
+    
+# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
+RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
+    tar --strip-components=1 -C /usr/bin/ -xz \
+    ghr_v${ghrversion}_linux_amd64/ghr
+
+ENV CC "arm-linux-gnueabihf-gcc -march=armv8-a -isystem /usr/local/include"
+RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv8-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
+    && cd termcap-${termcapversion} \
+    && ./configure --host=armv8-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r termcap-${termcapversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
+    && cd readline-${readlineversion} \
+    && ./configure --host=armv8-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) \
+    && make install-static \
+    && ls /usr/local/lib/ \
+    && cd .. \
+    && rm -r readline-${readlineversion}
+
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:buster
 
+# For FTL test compilation
+ARG CIRCLE_JOB="x86_32"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -63,6 +68,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -1,8 +1,9 @@
-FROM debian:stretch
+FROM debian:buster
 
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -18,7 +19,6 @@ RUN dpkg --add-architecture i386 \
         git \
         libcap2-bin \
         libcap-dev:i386 \
-        libidn11-dev:i386 \
         make \
         netcat-traditional \
         nettle-dev:i386 \
@@ -38,6 +38,13 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
 ENV CC "gcc -m32"
 RUN ln -s /usr/lib32/libm.so /usr/local/lib/
 
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
+
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
     && ./configure --enable-static --disable-shared --disable-doc --without-examples \
@@ -56,6 +63,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
-#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Uncomment the following line to test-compile FTL development during docker container development
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -13,8 +14,8 @@ RUN apk add --no-cache \
         curl \
         gmp-dev \
         libcap \
-        libidn-dev \
         linux-headers \
+        nettle-static \
         nettle-dev \
         openssh-client \
         shadow \
@@ -29,6 +30,13 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
 
 ENV CC gcc
 ENV STATIC true
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
@@ -48,6 +56,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
+# Uncomment the following line to test-compile FTL development during docker container development
 # RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
 #     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -1,5 +1,10 @@
 FROM alpine:3.12
 
+# For FTL test compilation
+ARG CIRCLE_JOB="x86_64-musl"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -56,6 +61,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && readelf -l ./pihole-FTL \
+    && cd .. \
+    && rm -r FTL

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -1,8 +1,9 @@
-FROM debian:stretch
+FROM debian:buster
 
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
+ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -17,7 +18,6 @@ RUN apt-get update \
         libcap2-bin \
         libcap-dev \
         libc-dev \
-        libidn11-dev \
         make \
         netcat-traditional \
         nettle-dev \
@@ -34,6 +34,13 @@ RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr
     ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC gcc
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
@@ -53,6 +60,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL master during docker container development
-#RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#    && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Uncomment the following line to test-compile FTL development during docker container development
+# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
+#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:buster
 
+# For FTL test compilation
+ARG CIRCLE_JOB="x86_64"
+ARG CIRCLE_TAG="test-build"
+ARG BRANCH="special/CI_development"
+
 # ghr 0.13.0 2019-09-16
 ARG ghrversion=0.13.0
 
@@ -60,6 +65,12 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
-# Uncomment the following line to test-compile FTL development during docker container development
-# RUN git clone https://github.com/pi-hole/FTL.git && cd FTL && git checkout development \
-#     && bash build.sh -DLUA_READLINE=true && readelf -A ./pihole-FTL
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the test step to be able to update the arch_tests if a change is intended
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${BRANCH}" \
+    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash test/arch_test.sh \
+    && cd .. \
+    && rm -r FTL


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

1. Update `ftl-build` containers to `debian:buster` where applicable.
   **Note**: This sets the minimum supported kernel to Linux 3.2.0 (January 2012) for binaries built with these containers

   We no **not** update the containers:
      - `armv4t`: `debian:buster` dropped `armv4t` compatibility
      - `armv6hf`: There is a bug in `debian:buster`'s cross-compilation `libc` missing `fnctl64`

2. We furthermore update `x64_64-musl`-container to latest `alpine:3.12`

3. Always *clone and test-compile* FTL's source from the protected branch `special/CI_development`. This ensures external contributions (and we ourselves) can see much more easily if changes/updates we do in the containers are good or not because the target architecture, FPU-requirements, minimum kernel versions, etc. are automatically checked during the container generation.

Points 1 and 2 make this PR superseding #14 which was not accepted before as there were more changes to be done to the building system than were not very obvious *without* a test compilation (which is included by default now due to no. 3 above).