### PR TITLE
Downgrade FTL containers to stretch due to glibc incompatibilities

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -65,7 +65,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stretch
 
 # For FTL test compilation
 ARG CIRCLE_JOB="aarch64"

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -1,4 +1,4 @@
-# Note that this has to stay at stretch as buster removed ARMv4T compliance
+# Note that this has to stay at stretch as stretch removed ARMv4T compliance
 FROM debian:stretch
 
 # For FTL test compilation

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -75,7 +75,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stretch
 
 # For FTL test compilation
 ARG CIRCLE_JOB="armv5te"

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -1,4 +1,4 @@
-# We cannot use stretch here due to libc-incompatibilities (undefined reference to `fcntl64')
+# We cannot use buster here due to glibc version incompatibilities
 FROM debian:stretch
 
 # For FTL test compilation

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -91,7 +91,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stretch
 
 # For FTL test compilation
 ARG CIRCLE_JOB="armv7hf"

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stretch
 
 # For FTL test compilation
 ARG CIRCLE_JOB="armv8a"

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stretch
 
 # For FTL test compilation
 ARG CIRCLE_JOB="x86_32"

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -66,7 +66,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && readelf -l ./pihole-FTL \
     && cd .. \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -70,7 +70,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${BRANCH}" \
-    && bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
+    && bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}" \
     && bash test/arch_test.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stretch
 
 # For FTL test compilation
 ARG CIRCLE_JOB="x86_64"


### PR DESCRIPTION
We're seeing issues with users on `stretch` bot being able to run the latest FTL binaries. Downgrade the FTL build containers to `stretch` will ensure `stretch` users will have a recent enough `glibc` for FTL.