### PR TITLE
Add jq and xxd for FTL API tests

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture arm64 \
         binutils \
         cmake \
         libc6-dev:arm64 \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture arm64 \
         binutils \
         cmake \
         libc6-dev:arm64 \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -35,6 +35,7 @@ RUN dpkg --add-architecture armel \
         binutils \
         cmake \
         libc6:armel \
+        jq \
     && rm -rf /var/lib/apt/lists/*
     
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -35,6 +35,7 @@ RUN dpkg --add-architecture armel \
         binutils \
         cmake \
         libc6:armel \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
     

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armel \
         binutils \
         cmake \
         libc6:armel \
+        jq \
     && rm -rf /var/lib/apt/lists/*
     
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armel \
         binutils \
         cmake \
         libc6:armel \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
     

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -17,22 +17,23 @@ ARG termcapversion=1.3.1
 RUN dpkg --add-architecture armel \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    wget \
-    git \
-    ca-certificates \
-    curl \
-    make \
-    file \
-    netcat-traditional \
-    ssh \
-    sqlite3 \
-    dnsutils \
-    binutils \
-    cmake \
-    nettle-dev:armel \
-    libcap-dev:armel \
-    libgmp-dev:armel \
-    libc6-dev:armel \
+        wget \
+        git \
+        ca-certificates \
+        curl \
+        make \
+        file \
+        netcat-traditional \
+        ssh \
+        sqlite3 \
+        dnsutils \
+        binutils \
+        cmake \
+        nettle-dev:armel \
+        libcap-dev:armel \
+        libgmp-dev:armel \
+        libc6-dev:armel \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armel \
         libcap-dev:armel \
         libgmp-dev:armel \
         libc6-dev:armel \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armhf \
         binutils \
         cmake \
         libc6:armhf \
+        jq \
     && rm -rf /var/lib/apt/lists/*
     
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armhf \
         binutils \
         cmake \
         libc6:armhf \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
     

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armhf \
         binutils \
         cmake \
         libc6:armhf \
+        jq \
     && rm -rf /var/lib/apt/lists/*
     
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture armhf \
         binutils \
         cmake \
         libc6:armhf \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
     

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture i386 \
         binutils \
         cmake \
         libc6:i386 \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --add-architecture i386 \
         binutils \
         cmake \
         libc6:i386 \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
         sqlite \
         binutils \
         cmake \
+        xxd \
         jq
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -26,7 +26,8 @@ RUN apk add --no-cache \
         shadow \
         sqlite \
         binutils \
-        cmake
+        cmake \
+        jq
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         wget \
         binutils \
         cmake \
+        xxd \
         jq \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         wget \
         binutils \
         cmake \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The command-line JSON processor `jq` is like `sed` for JSON data - you can use it to slice and filter and map and transform structured data with the same ease that `sed`, `awk`, `grep` and friends let you play with text.

This PR adds `jq` into the containers to be used in future tests of the REST/JSON API embedded into FTL.

Example for why it's useful:
```bash
# Extracting a string
$ curl -s 127.0.0.1/api/auth | jq ".challenge"
"b97c1507ce064909add6e44dd18a6d325ea82c5e48e5911ab68d2d06687eea6f"

# Extracting a boolean
$ curl -s 127.0.0.1/api/ftl/system | jq ".dns.blocking"
true

# it can even so computations (if ever needed)
$ curl -s 127.0.0.1/api/ftl/system | jq ".memory.ram.used / .memory.ram.total"
0.1233328411831291
```

---

`xxd` is used to compile the API documentation into hex code that can be embedded into FTL at compile-time.