### PR TITLE
Update included libidn (1.36 -> 1.41) and libreadline (8.0 -> 8.1)

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -5,7 +5,8 @@ ARG CI_ARCH="aarch64"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN dpkg --add-architecture arm64 \
@@ -19,7 +20,6 @@ RUN dpkg --add-architecture arm64 \
         libc-dev-arm64-cross \
         libcap-dev:arm64 \
         libcap2-bin \
-        libidn11-dev:arm64 \
         make \
         netcat-traditional \
         nettle-dev:arm64 \
@@ -42,6 +42,13 @@ RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-fr
         dnsutils
 
 ENV CC aarch64-linux-gnu-gcc -isystem /usr/local/include
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
+    && cd libidn-${idnversion} \
+    && ./configure --host=aarch64-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libidn-${idnversion}
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -6,8 +6,8 @@ ARG CI_ARCH="armv4t"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN dpkg --add-architecture armel \

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -47,7 +47,7 @@ RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -5,8 +5,8 @@ ARG CI_ARCH="armv5te"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN dpkg --add-architecture armel \

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -45,7 +45,7 @@ RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -6,8 +6,8 @@ ARG CI_ARCH="armv6hf"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 # Packages required to install compiler and libraries

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -5,8 +5,8 @@ ARG CI_ARCH="armv7hf"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN dpkg --add-architecture armhf \

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -5,8 +5,8 @@ ARG CI_ARCH="armv8a"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN dpkg --add-architecture armhf \

--- a/ftl-build/test_build.sh
+++ b/ftl-build/test_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+# Walk subdirectories
+for dir in ./*/
+do
+        pushd "$dir"
+        docker build .
+        popd
+done

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -5,8 +5,8 @@ ARG CI_ARCH="x86_32"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN dpkg --add-architecture i386 \

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -69,7 +69,7 @@ RUN ln -s /usr/lib32/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -6,8 +6,8 @@ ARG CI_ARCH="x86_64-musl"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN apk add --no-cache \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -5,8 +5,8 @@ ARG CI_ARCH="x86_64"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-ARG idnversion=1.36
-ARG readlineversion=8.0
+ARG idnversion=1.41
+ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
 RUN apt-get update \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -66,7 +66,7 @@ ENV CC gcc
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Update included libidn (1.36 -> 1.41) and libreadline (8.0 -> 8.1)

`libidn CHANGELOG`
```
* Noteworthy changes in release 1.41 (2022-06-25) [stable]

** Bump LT_REVISION for new release.
It was mistakenly left at the same value since 1.38.

** Add version number related self-checks.

* Noteworthy changes in release 1.40 (2022-06-20) [stable]

** lib: Bump STRINGPREP_VERSION to 1.40.
It was mistakenly left at 1.38 in the 1.39 release.

* Noteworthy changes in release 1.39 (2022-06-20) [stable]

** lib: Code detecting current locale broken since 1.36.
The code always returned ASCII.  The precise cause is complicated to
track down but likely boils down to the new autotools/gettext
bootstrapping sequence introduced in release 1.36.  Reported by Ð‘Ð¾Ð³Ð´Ð°Ð½
ÐŸÐ¸Ð»Ð¸Ð¿ÐµÐ½ÐºÐ¾ <bogdan.pylypenko107@gmail.com>.

** maint: Java JAR archive no longer included in source tarball.

** Minor fixes: typos, makefiles, indentation, gnulib update, etc.

* Noteworthy changes in release 1.38 (2021-07-22) [stable]

** doc: Simplify building of gdoc-generated man/texi outputs.
Now the targets are rebuilt on version number changes properly.

** doc: Improve GTK-DOC manual.

** build: Fix build errors related to doc/idn--help.texi.

** build: Fix --disable-tld builds.
Now tld_strerror() is removed when --disable-tld is used.

* Noteworthy changes in release 1.37 (2021-05-15) [stable]

** doc: Minor fixes and codespell typos.

** Updated translations.

** Update gnulib files and build fixes.
We now use gnulib's ./bootstrap and gnulib's readme-release
infrastructure for making releases.

** API and ABI is backwards compatible with the previous version.
```

`readline` CHANGELOG
```
1. Changes to Readline

a. There are a number of fixes that were found as the result of fuzzing with
   random input.

b. Changed the revert-all-at-newline behavior to make sure to start at the end
   of the history list when doing it, instead of the line where the user hit
   return.

c. When parsing `set' commands from the inputrc file or an application, readline
   now allows trailing whitespace.

d. Fixed a bug that left a file descriptor open to the history file if the
   file size was 0.

e. Fixed a problem with binding key sequences containing meta characters.

f. Fixed a bug that caused the wrong line to be displayed if the user tried to
   move back beyond the beginning of the history list, or forward past the end
   of the history list.

g. If readline catches SIGTSTP, it now sets a hook that allows the calling
   application to handle it if it desires.

h. Fixed a redisplay problem with a prompt string containing embedded newlines.

i. Fixed a problem with completing filenames containing invalid multibyte
   sequences when case-insensitive comparisons are enabled.

j. Fixed a redisplay problem with prompt strings containing invisible multibyte
   characters.

k. Fixed a problem with multibyte characters mapped to editing commands that
   modify the search string in incremental search.

l. Fixed a bug with maintaining the key sequence while resolving a bound
   command in the presence of ambiguous sequences (sequences with a common
   prefix), in most cases while attempting to unbind it.

m. Fixed several buffer overflows found as the result of fuzzing.

n. Reworked backslash handling when translating key sequences for key binding
   to be more uniform and consistent, which introduces a slight backwards
   incompatibility.

o. Fixed a bug with saving the history that resulted in errors not being
   propagated to the calling application when the history file is not writable.

p. Readline only calls chown(2) on a newly-written history file if it really
   needs to, instead of having it be a no-op.

q. Readline now behaves better when operate-and-get-next is used when the
   history list is `full': when there are already $HISTSIZE entries.

r. Fixed a bug that could cause vi redo (`.') of a replace command not to work
   correctly in the C or POSIX locale.

s. Fixed a bug with vi-mode digit arguments that caused the last command to be
   set incorrectly. This prevents yank-last-arg from working as intended, for
   example.

t. Make sure that all undo groups are closed when leaving vi insertion mode.  

u. Make sure that the vi-mode `C' and `c' commands enter insert mode even if
   the motion command doesn't have any effect.

v. Fixed several potential memory leaks in the callback mode context handling.

w. If readline is handling a SIGTTOU, make sure SIGTTOU is blocked while
   executing the terminal cleanup code, since it's no longer run in a signal
   handling context.

x. Fixed a bug that could cause an application with an application-specific 
   redisplay function to crash if the line data structures had not been
   initialized.

y. Terminals that are named "dumb" or unknown do not enable bracketed paste
   by default.

z. Ensure that disabling bracketed paste turns off highlighting the incremental
   search string when the search is successful.

2. New Features in Readline

a. If a second consecutive completion attempt produces matches where the first
   did not, treat it as a new completion attempt and insert a match as
   appropriate.

b. Bracketed paste mode works in more places: incremental search strings, vi
   overstrike mode, character search, and reading numeric arguments.

c. Readline automatically switches to horizontal scrolling if the terminal has
   only one line.

d. Unbinding all key sequences bound to a particular readline function now
   descends into keymaps for multi-key sequences.

e. rl-clear-display: new bindable command that clears the screen and, if
   possible, the scrollback buffer (bound to emacs mode M-C-l by default).

f. New active mark and face feature: when enabled, it will highlight the text
   inserted by a bracketed paste (the `active region') and the text found by
   incremental and non-incremental history searches. This is tied to bracketed
   paste and can be disabled by turning off bracketed paste.

g. Readline sets the mark in several additional commands.

h. Bracketed paste mode is enabled by default. There is a configure-time
   option (--enable-bracketed-paste-default) to set the default to on or off.

i. Readline tries to take advantage of the more regular structure of UTF-8
   characters to identify the beginning and end of characters when moving
   through the line buffer.

j. The bindable operate-and-get-next command (and its default bindings) are
   now part of readline instead of a bash-specific addition.

k. The signal cleanup code now blocks SIGINT while processing after a SIGINT. 
```

This PR furthermore fixes a copy-past-error in the `host` attribute when compiling `libidn` and adds a convenient test script that can be used to verify modified containers are still able to build and compile a working version of a recent FTL version.

**How does this PR accomplish the above?:**

Update version strings

**What documentation changes (if any) are needed to support this PR?:**

None