### PR TITLE
Use powerDNS 4.4 in Debian containers

### DIFF
--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -35,6 +35,7 @@ RUN dpkg --add-architecture i386 \
         xxd \
         jq \
         gnupg \
+        psmisc \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
         xxd \
         jq \
         gnupg \
+        psmisc \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor


### PR DESCRIPTION
Bump `pdns` to 4.4 in the debian containers
Add `psmisc` for `killall`