### PR TITLE
Run tests as part of building the build container

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -5,9 +5,6 @@ ARG CIRCLE_JOB="aarch64"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
 
@@ -41,11 +38,6 @@ RUN dpkg --add-architecture arm64 \
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC aarch64-linux-gnu-gcc -isystem /usr/local/include
 

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -6,9 +6,6 @@ ARG CIRCLE_JOB="armv4t"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -42,11 +39,6 @@ RUN dpkg --add-architecture armel \
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC "arm-linux-gnueabi-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -5,9 +5,6 @@ ARG CIRCLE_JOB="armv5te"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -40,11 +37,6 @@ RUN dpkg --add-architecture armel \
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC "arm-linux-gnueabi-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -6,9 +6,6 @@ ARG CIRCLE_JOB="armv6hf"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -40,11 +37,6 @@ RUN dpkg --add-architecture armel \
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 # Use Raspbian's GCC
 # This command was taken from https://github.com/dockcross/dockcross/blob/master/linux-armv6/Dockerfile

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -5,9 +5,6 @@ ARG CIRCLE_JOB="armv7hf"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -40,11 +37,6 @@ RUN dpkg --add-architecture armhf \
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -5,9 +5,6 @@ ARG CIRCLE_JOB="armv8a"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -40,11 +37,6 @@ RUN dpkg --add-architecture armhf \
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC "arm-linux-gnueabihf-gcc -march=armv8-a -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -5,9 +5,6 @@ ARG CIRCLE_JOB="x86_32"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -64,11 +61,6 @@ RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC "gcc -m32"
 RUN ln -s /usr/lib32/libm.so /usr/local/lib/

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -6,9 +6,6 @@ ARG CIRCLE_JOB="x86_64-musl"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -39,11 +36,6 @@ RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VER}/communi
     pdns-backend-sqlite3 \
     pdns-recursor \
     pdns-doc
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC gcc
 ENV STATIC true

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -5,9 +5,6 @@ ARG CIRCLE_JOB="x86_64"
 ARG CIRCLE_TAG="test-build"
 ARG BRANCH="special/CI_development"
 
-# ghr 0.13.0 2019-09-16
-ARG ghrversion=0.13.0
-
 ARG idnversion=1.36
 ARG readlineversion=8.0
 ARG termcapversion=1.3.1
@@ -62,11 +59,6 @@ RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_
 RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get -t stretch-backports install git -y
-
-# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
-RUN curl -sSL https://github.com/tcnksm/ghr/releases/download/v${ghrversion}/ghr_v${ghrversion}_linux_amd64.tar.gz | \
-    tar --strip-components=1 -C /usr/bin/ -xz \
-    ghr_v${ghrversion}_linux_amd64/ghr
 
 ENV CC gcc
 


### PR DESCRIPTION
Per title. This should ensure changes to the build containers don't break the tests (or if they do, we find out before we publish the changes)