### PR TITLE
Update ftl-build containers

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="aarch64"
@@ -31,15 +31,9 @@ RUN dpkg --add-architecture arm64 \
         libc6-dev:arm64 \
         xxd \
         jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-# stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t stretch-backports install --no-install-recommends -y \
         git \
-        dnsutils
+        dnsutils \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CC aarch64-linux-gnu-gcc -isystem /usr/local/include
 

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -40,7 +40,8 @@ RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-fr
     && apt-get update \
     && apt-get -t stretch-backports install --no-install-recommends -y \
         git \
-        dnsutils
+        dnsutils \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CC "arm-linux-gnueabi-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="armv5te"
@@ -30,15 +30,9 @@ RUN dpkg --add-architecture armel \
         libc6:armel \
         xxd \
         jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-# stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t stretch-backports install --no-install-recommends -y \
         git \
-        dnsutils
+        dnsutils \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CC "arm-linux-gnueabi-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -1,4 +1,4 @@
-# We cannot use buster here due to glibc version incompatibilities
+# The official Raspberry Pi toolchain isn't compatible with Buster
 FROM debian:stretch
 
 # For FTL test compilation

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -1,5 +1,4 @@
-# The official Raspberry Pi toolchain isn't compatible with Buster
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="armv6hf"
@@ -31,33 +30,25 @@ RUN dpkg --add-architecture armel \
         libc6-dev:armel \
         xxd \
         jq \
+        git \
     && rm -rf /var/lib/apt/lists/*
 
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list; \
-    apt-get update; \
-    apt-get -t stretch-backports install git -y
+# Use cross-compiler from https://github.com/abhiTronix/raspberry-pi-cross-compilers
+# Configuration: builder = any 64bit Linux
+#                target = optimized for Raspberry Pi Zero, GCC version 10.3.0
+RUN curl -sSL https://ftl.pi-hole.net/libraries/cross-gcc-10.3.0-pi_0-1.tar.gz | tar -xz
+ENV PATH "/cross-pi-gcc-10.3.0-0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV LD_LIBRARY_PATH "/cross-pi-gcc-10.3.0-0/lib:/cross-pi-gcc-10.3.0-0/arm-linux-gnueabihf/libc/usr/lib/"
 
-# Use Raspbian's GCC
-# This command was taken from https://github.com/dockcross/dockcross/blob/master/linux-armv6/Dockerfile
-# Slightly modified from the original
-RUN mkdir rpi_tools && cd rpi_tools && git init && git remote add origin https://github.com/raspberrypi/tools && \
-    git config core.sparseCheckout true && \
-    echo "arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf" >> .git/info/sparse-checkout && \
-    git pull --depth=1 origin master && \
-    cp -a arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/* /usr/ && rm -rf ../rpi_tools
+# We use the libnettle and libidn headers from the armel packages, however, we
+# use the armv6 compatible libraries we built on a Raspberry Pi Zero
+ENV CC "arm-linux-gnueabihf-gcc -isystem/usr/include -isystem/usr/include/arm-linux-gnueabi -isystem/usr/local/include"
+RUN ln -s /cross-pi-gcc-10.3.0-0/arm-linux-gnueabihf/libc/usr/lib/libm.so /usr/local/lib/
 
 # Download procompiled armv6 libraries
 RUN wget https://ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
     wget https://ftl.pi-hole.net/libraries/libnettle.a -O /usr/local/lib/libnettle.a && \
     wget https://ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a
-
-# We use the libnettle and libidn headers from the armel packages, however, we
-# use the armv6 compatible libraries we built on a Raspberry Pi Zero and
-# uploaded them to ftl.pi-hole.net. Note that we do NOT include
-# -L/usr/lib/arm-linux-gnueabihf here as this would result in incompatible binaries
-ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/include -isystem /usr/include/arm-linux-gnueabi -isystem /usr/local/include -L/usr/local/lib"
-RUN ln -s /usr/arm-linux-gnueabihf/sysroot/usr/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="armv7hf"
@@ -30,15 +30,9 @@ RUN dpkg --add-architecture armhf \
         libc6:armhf \
         xxd \
         jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-# stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t stretch-backports install --no-install-recommends -y \
         git \
-        dnsutils
+        dnsutils \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CC "arm-linux-gnueabihf-gcc -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="armv8a"
@@ -30,15 +30,9 @@ RUN dpkg --add-architecture armhf \
         libc6:armhf \
         xxd \
         jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-# stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t stretch-backports install --no-install-recommends -y \
         git \
-        dnsutils
+        dnsutils \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CC "arm-linux-gnueabihf-gcc -march=armv8-a -isystem /usr/local/include"
 RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/

--- a/ftl-build/test_build.sh
+++ b/ftl-build/test_build.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
-
 # Walk subdirectories
 for dir in ./*/
 do
         pushd "$dir"
-        docker build .
+        if ! docker build .; then
+          echo "$dir - FAILED"
+          exit 1
+        else
+          echo "$dir - SUCCESS"
+        fi
         popd
 done
+echo "ALL DONE"

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -9,7 +9,9 @@ ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
+# We need a more recent dnsutils version for native HTTPS and SVCB support in dig
 RUN dpkg --add-architecture i386 \
+    && echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates \
@@ -32,6 +34,9 @@ RUN dpkg --add-architecture i386 \
         jq \
         gnupg \
         psmisc \
+        git \
+    && apt-get -t buster-backports install --no-install-recommends -y \
+        dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor
@@ -46,14 +51,6 @@ RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-46 main" 
 # Wget the pdns-backend-sqlite3.deb and install it
 RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb; \
     dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
-
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-# stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t stretch-backports install --no-install-recommends -y \
-        git \
-        dnsutils
 
 ENV CC "gcc -m32"
 RUN ln -s /usr/lib32/libm.so /usr/local/lib/

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="x86_32"
@@ -35,26 +35,17 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian stretch-auth-44 main" >> /etc/apt/sources.list.d/pdns.list; \
-    echo "Package: pdns-*" > /etc/apt/preferences.d/pdns; \
-    echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns; \
-    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns; \
-    curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - ; \
-    apt-get update; \
-    apt-get install pdns-server -y;
-
-# Pin powerdns repo in APT to get pdns-recursor
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian stretch-rec-44 main" >> /etc/apt/sources.list.d/pdns.list; \
-    echo "Package: pdns-*" > /etc/apt/preferences.d/pdns; \
-    echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns; \
-    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns; \
-    curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - ; \
-    apt-get update; \
-    apt-get install pdns-recursor -y;
+RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-44 main" >> /etc/apt/sources.list.d/pdns.list && \
+    echo "Package: pdns-*" > /etc/apt/preferences.d/pdns && \
+    echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns && \
+    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns && \
+    curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install pdns-server pdns-recursor -y
 
 # Wget the pdns-backend-sqlite3.deb and install it
-RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.4.3-1pdns.stretch_amd64.deb; \
-    dpkg -i pdns-backend-sqlite3_4.4.3-1pdns.stretch_amd64.deb
+RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb; \
+    dpkg -i pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb
 
 # Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
 # stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -35,7 +35,7 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-44 main" >> /etc/apt/sources.list.d/pdns.list && \
+RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-46 main" >> /etc/apt/sources.list.d/pdns.list && \
     echo "Package: pdns-*" > /etc/apt/preferences.d/pdns && \
     echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns && \
     echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns && \
@@ -44,8 +44,8 @@ RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-44 main" 
     apt-get install pdns-server pdns-recursor -y
 
 # Wget the pdns-backend-sqlite3.deb and install it
-RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb; \
-    dpkg -i pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb
+RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb; \
+    dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
 
 # Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
 # stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VER=3.14
+ARG ALPINE_VER=3.16
 FROM alpine:${ALPINE_VER}
 
 # For FTL test compilation

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # For FTL test compilation
 ARG CI_ARCH="x86_64"
@@ -33,26 +33,17 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian stretch-auth-44 main" >> /etc/apt/sources.list.d/pdns.list; \
-    echo "Package: pdns-*" > /etc/apt/preferences.d/pdns; \
-    echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns; \
-    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns; \
-    curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - ; \
-    apt-get update; \
-    apt-get install pdns-server -y;
-
-# Pin powerdns repo in APT to get pdns-recursor
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian stretch-rec-44 main" >> /etc/apt/sources.list.d/pdns.list; \
-    echo "Package: pdns-*" > /etc/apt/preferences.d/pdns; \
-    echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns; \
-    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns; \
-    curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - ; \
-    apt-get update; \
-    apt-get install pdns-recursor -y;
+RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-44 main" >> /etc/apt/sources.list.d/pdns.list && \
+    echo "Package: pdns-*" > /etc/apt/preferences.d/pdns && \
+    echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns && \
+    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns && \
+    curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install pdns-server pdns-recursor -y
 
 # Wget the pdns-backend-sqlite3.deb and install it
-RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.4.3-1pdns.stretch_amd64.deb; \
-    dpkg -i pdns-backend-sqlite3_4.4.3-1pdns.stretch_amd64.deb
+RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb && \
+    dpkg -i pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb
 
 # Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
 # stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor
-RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-44 main" >> /etc/apt/sources.list.d/pdns.list && \
+RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-46 main" >> /etc/apt/sources.list.d/pdns.list && \
     echo "Package: pdns-*" > /etc/apt/preferences.d/pdns && \
     echo "Pin: origin repo.powerdns.com" >> /etc/apt/preferences.d/pdns && \
     echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns && \
@@ -42,8 +42,8 @@ RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-44 main" 
     apt-get install pdns-server pdns-recursor -y
 
 # Wget the pdns-backend-sqlite3.deb and install it
-RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb && \
-    dpkg -i pdns-backend-sqlite3_4.4.3-1pdns.buster_amd64.deb
+RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb && \
+    dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
 
 # Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
 # stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -9,7 +9,9 @@ ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 
-RUN apt-get update \
+# We need a more recent dnsutils version for native HTTPS and SVCB support in dig
+RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates \
         curl \
@@ -30,6 +32,9 @@ RUN apt-get update \
         jq \
         gnupg \
         psmisc \
+        git \
+    && apt-get -t buster-backports install --no-install-recommends -y \
+        dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin powerdns repo in APT to get pdns-recursor
@@ -44,14 +49,6 @@ RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-46 main" 
 # Wget the pdns-backend-sqlite3.deb and install it
 RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb && \
     dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
-
-# Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
-# stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t stretch-backports install --no-install-recommends -y \
-        git \
-        dnsutils
 
 ENV CC gcc
 


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Update the `ftl-build` containers (Debian Stretch -> Buster, Alpine 3.14 -> 3.16).

The `armv4t` container is *not* upgraded as Debian Stretch was the last release that supported `armv4t`. **Support for `armv4t` should be dropped by Pi-hole, too.**

The `armv6hf` container has been upgraded from the deprecated (and not maintained) official Raspberry Pi cross-compiler to [`abhiTronix/raspberry-pi-cross-compilers`](https://github.com/abhiTronix/raspberry-pi-cross-compilers) working fine on Buster (and also on Bullseye). We expect a performance gain as the compiler is upgraded from `gcc 4` (!) to the very recent `gcc 10.3.0`.

Furthermore, this PR updates the embedded PowerDNS (used by the testing suite) to the most recent stable version (from 4.3 to 4.6).


- **How does this PR accomplish the above?:**

Modify the `Dockerfile`s


- **What documentation changes (if any) are needed to support this PR?:**

Stretch support has already been dropped, no need for additional documentation changes.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [X] I have read the above and my PR is ready for review. _Check this box to confirm_
