### PR TITLE
Update ftl-build containers

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -8,6 +8,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 RUN dpkg --add-architecture arm64 \
     && apt-get update \
@@ -15,6 +16,7 @@ RUN dpkg --add-architecture arm64 \
         ca-certificates \
         curl \
         file \
+        build-essential \
         gcc-aarch64-linux-gnu \
         git \
         libc-dev-arm64-cross \
@@ -22,7 +24,8 @@ RUN dpkg --add-architecture arm64 \
         libcap2-bin \
         make \
         netcat-traditional \
-        nettle-dev:arm64 \
+        m4 \
+        libgmp-dev:arm64 \
         ssh \
         sqlite3 \
         wget \
@@ -39,7 +42,7 @@ ENV CC aarch64-linux-gnu-gcc -isystem /usr/local/include
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=aarch64-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=aarch64-linux-gnueabi --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -55,12 +58,19 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=aarch64-linux-gnu --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=aarch64-linux-gnu --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --host=aarch64-linux-gnueabi --enable-static --disable-shared --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -1,4 +1,4 @@
-# Note that this has to stay at stretch as stretch removed ARMv4T compliance
+# Note that this has to stay at stretch as buster removed ARMv4T compatibility
 FROM debian:stretch
 
 # For FTL test compilation
@@ -9,6 +9,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 RUN dpkg --add-architecture armel \
     && apt-get update \
@@ -16,6 +17,7 @@ RUN dpkg --add-architecture armel \
         ca-certificates \
         curl \
         file \
+        build-essential \
         gcc-arm-linux-gnueabi \
         libc6-dev-armel-cross \
         libcap-dev:armel \
@@ -23,7 +25,8 @@ RUN dpkg --add-architecture armel \
         libidn11-dev:armel \
         make \
         netcat-traditional \
-        nettle-dev:armel \
+        libgmp-dev:armel \
+        m4 \
         ssh \
         sqlite3 \
         wget \
@@ -48,7 +51,7 @@ RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -64,12 +67,19 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-fat --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -39,7 +39,7 @@ RUN ln -s /usr/arm-linux-gnueabi/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -55,7 +55,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=arm-linux-gnueabi --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -52,7 +52,7 @@ RUN wget https://ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a &
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -68,7 +68,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv6-linux-gnueabi --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -8,6 +8,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 RUN dpkg --add-architecture armhf \
     && apt-get update \
@@ -15,13 +16,15 @@ RUN dpkg --add-architecture armhf \
         ca-certificates \
         curl \
         file \
+        build-essential \
         gcc-arm-linux-gnueabihf \
         libc6-dev-armhf-cross \
         libcap-dev:armhf \
         libcap2-bin \
         make \
         netcat-traditional \
-        nettle-dev:armhf \
+        m4 \
+        libgmp-dev:armhf \
         ssh \
         sqlite3 \
         wget \
@@ -39,7 +42,7 @@ RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv7-linux-gnueabi --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -55,12 +58,19 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=armv7-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv7-linux-gnueabihf --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --host=armv7-linux-gnueabihf --enable-static --disable-shared --disable-fat --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -8,6 +8,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 RUN dpkg --add-architecture armhf \
     && apt-get update \
@@ -15,13 +16,15 @@ RUN dpkg --add-architecture armhf \
         ca-certificates \
         curl \
         file \
+        build-essential \
         gcc-arm-linux-gnueabihf \
         libc6-dev-armhf-cross \
         libcap-dev:armhf \
         libcap2-bin \
         make \
         netcat-traditional \
-        nettle-dev:armhf \
+        m4 \
+        libgmp-dev:armhf \
         ssh \
         sqlite3 \
         wget \
@@ -39,7 +42,7 @@ RUN ln -s /usr/arm-linux-gnueabihf/lib/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --host=armv8-linux-gnueabi --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv8-linux-gnueabi --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -55,12 +58,20 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --host=armv8-linux-gnueabihf --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --host=armv8-linux-gnueabihf --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+# --disable-fat is needed to prevent the wrong FP architecture (we expect VFPv3-D16 - without this option we get vFPv3)
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --host=armv8-linux-gnueabihf --enable-static --disable-shared --disable-fat --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/test_build.sh
+++ b/ftl-build/test_build.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
+COL_NC="\x1b[0m"
+COL_BOLD="\x1b[1m"
+COL_GREEN="\x1b[32m"
+COL_RED="\x1b[91m"
+
 # Walk subdirectories
 for dir in ./*/
 do
         pushd "$dir"
         if ! docker build .; then
-          echo "$dir - FAILED"
+          echo -e "${COL_BOLD}  $dir - ${COL_RED}FAILED${COL_NC}"
           exit 1
         else
-          echo "$dir - SUCCESS"
+          echo -e "${COL_BOLD}  $dir - ${COL_GREEN}SUCCESS${COL_NC}"
         fi
         popd
 done

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -8,6 +8,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 # We need a more recent dnsutils version for native HTTPS and SVCB support in dig
 RUN dpkg --add-architecture i386 \
@@ -23,7 +24,8 @@ RUN dpkg --add-architecture i386 \
         libcap-dev:i386 \
         make \
         netcat-traditional \
-        nettle-dev:i386 \
+        m4 \
+        libgmp-dev:i386 \
         sqlite3 \
         ssh \
         wget \
@@ -57,7 +59,7 @@ RUN ln -s /usr/lib32/libm.so /usr/local/lib/
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -73,12 +75,19 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --enable-static --disable-shared --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git \

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -9,6 +9,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 RUN apk add --no-cache \
         alpine-sdk \
@@ -18,15 +19,14 @@ RUN apk add --no-cache \
         gmp-dev \
         libcap \
         linux-headers \
-        nettle-static \
-        nettle-dev \
         openssh-client \
         shadow \
         sqlite \
         binutils \
         cmake \
         xxd \
-        jq
+        jq \
+        m4
 
 # Install pdns from community repo
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VER}/community" >> /etc/apk/repositories; \
@@ -42,7 +42,7 @@ ENV STATIC true
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -58,12 +58,19 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --enable-static --disable-shared --enable-mini-gmp \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -8,6 +8,7 @@ ARG GIT_BRANCH="special/CI_development"
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
+ARG nettleversion=3.8
 
 # We need a more recent dnsutils version for native HTTPS and SVCB support in dig
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list \
@@ -22,7 +23,8 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
         libc-dev \
         make \
         netcat-traditional \
-        nettle-dev \
+        m4 \
+        libgmp-dev \
         sqlite3 \
         ssh \
         wget \
@@ -54,7 +56,7 @@ ENV CC gcc
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
     && cd libidn-${idnversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r libidn-${idnversion}
@@ -70,12 +72,19 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --without-examples \
+    && ./configure --enable-static --disable-shared --disable-install-examples \
     && make -j $(nproc) \
     && make install-static \
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
+    && cd nettle-${nettleversion} \
+    && ./configure --enable-static --disable-shared --enable-mini-gmp \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nettle-${nettleversion}
 
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git \


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Provide more recent `nettle` library to fix missing DNSSEC/Ed448 support in FTL


- **How does this PR accomplish the above?:**

Compile nettle from source instead of relying on whatever version is provided by the building distribution for all architectures but `armv5te` (`armel` and `amd64` `libc6` conflict in `debian:buster`).

We remove the distro-provided `nettle` packages and add `libgmp` instead (used by `nettle` for huge number computations, think of RSA and ECDSA). We also have to add `build-essential` as `nettle` has a multi-stage compilation step with intermediate code running locally on the building hoist for generating the various `*data.c` programs needed for `shadata`.

This PR furthermore fixes unknown flag warnings thrown by `./configure` that have been missed in previous version updates of the libraries (they have no effect else than making the built containers a tiny bit smaller).


- **What documentation changes (if any) are needed to support this PR?:**

None


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [X] I have read the above and my PR is ready for review. _Check this box to confirm_
