### PR TITLE
Separate building and testing the FTL image

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -60,11 +60,25 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build
         uses: docker/build-push-action@v3
         with:
           context: ftl-build/${{ matrix.ARCH }}/.
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          target: tester
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Caching disabled for now...
+          # cache-from: type=gha,scope=${{ matrix.ARCH }}
+          # cache-to: type=gha,scope=${{ matrix.ARCH }},mode=max
+      -
+        name: Push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v3
+        with:
+          context: ftl-build/${{ matrix.ARCH }}/.
+          push: true
+          target: builder
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Caching disabled for now...

--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -1,9 +1,4 @@
-FROM debian:buster
-
-# For FTL test compilation
-ARG CI_ARCH="aarch64"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -71,6 +66,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="aarch64"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -1,10 +1,5 @@
 # Note that this has to stay at stretch as buster removed ARMv4T compatibility
-FROM debian:stretch
-
-# For FTL test compilation
-ARG CI_ARCH="armv4t"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:stretch AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -80,6 +75,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="armv4t"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv5te/Dockerfile
+++ b/ftl-build/armv5te/Dockerfile
@@ -1,10 +1,5 @@
 # Issue with apt-get in latest buster base for armel packages - pin to specific digest until it is fixed upstream
-FROM debian:buster@sha256:0685c900f6e691bdda6980c0ed0779d20183bc58770059b64adb56cb8a3129f0
-
-# For FTL test compilation
-ARG CI_ARCH="armv5te"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster@sha256:0685c900f6e691bdda6980c0ed0779d20183bc58770059b64adb56cb8a3129f0 AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -62,6 +57,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="armv5te"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv6hf/Dockerfile
+++ b/ftl-build/armv6hf/Dockerfile
@@ -1,10 +1,5 @@
 # Issue with apt-get in latest buster base for armel packages - pin to specific digest until it is fixed upstream
-FROM debian:buster@sha256:0685c900f6e691bdda6980c0ed0779d20183bc58770059b64adb56cb8a3129f0
-
-# For FTL test compilation
-ARG CI_ARCH="armv6hf"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster@sha256:0685c900f6e691bdda6980c0ed0779d20183bc58770059b64adb56cb8a3129f0 AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -77,6 +72,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && ls /usr/local/lib/ \
     && cd .. \
     && rm -r readline-${readlineversion}
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="armv6hf"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -1,9 +1,4 @@
-FROM debian:buster
-
-# For FTL test compilation
-ARG CI_ARCH="armv7hf"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -71,6 +66,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="armv7hf"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -1,9 +1,4 @@
-FROM debian:buster
-
-# For FTL test compilation
-ARG CI_ARCH="armv8a"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -72,6 +67,13 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="armv8a"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -1,9 +1,4 @@
-FROM debian:buster
-
-# For FTL test compilation
-ARG CI_ARCH="x86_32"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -94,6 +89,13 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core
 
 ENV BATS=/bats-core/bin/bats
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="x86_32"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the arch_test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -1,10 +1,5 @@
 ARG ALPINE_VER=3.16
-FROM alpine:${ALPINE_VER}
-
-# For FTL test compilation
-ARG CI_ARCH="x86_64-musl"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM alpine:${ALPINE_VER} AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -77,6 +72,13 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core
 
 ENV BATS=/bats-core/bin/bats
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="x86_64-musl"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the arwch_test step to be able to update the arch_tests if a change is intended

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -1,9 +1,4 @@
-FROM debian:buster
-
-# For FTL test compilation
-ARG CI_ARCH="x86_64"
-ARG GIT_TAG="test-build"
-ARG GIT_BRANCH="special/CI_development"
+FROM debian:buster AS builder
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
@@ -91,6 +86,13 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core
 
 ENV BATS=/bats-core/bin/bats
+
+FROM builder AS tester
+
+# For FTL test compilation
+ARG CI_ARCH="x86_64"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # We accept errors in the arch_test step to be able to update the arch_tests if a change is intended


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When the FTL base image is build, in the last step it is building `FTL` from source to test the built environment. Afterwards it's removing the source directory. However, three images (`x86_64`, `x86_64-musl`and `x86_32`) run more extensive tests (`test/run.sh`) which leave modifications to the images.

```
container-diff-linux-amd64 diff daemon://ftl_base_x86_64_full daemon://ftl_base_x86_64_no_ftl --type=file

-----File-----

These entries have been added to ftl_base_x86_64_full: None

These entries have been deleted from ftl_base_x86_64_full:
FILE                                      SIZE
/etc/dnsmasq.conf                         880B
/etc/pihole                               172.2K
/etc/pihole/gravity.db                    92K
/etc/pihole/pihole-FTL.conf               179B
/etc/pihole/pihole-FTL.db                 80K
/etc/pihole/setupVars.conf                22B
/etc/subgid-                              0
/etc/subuid-                              0
/home/pihole                              4.4K
/home/pihole/.bash_logout                 220B
/home/pihole/.bashrc                      3.4K
/home/pihole/.profile                     807B
/opt/pihole                               9.3K
/opt/pihole/libs                          9.3K
/opt/pihole/libs/inspect.lua              9.3K
/root/.pihole_lua_history                 0
/root/.sqlite_history                     6B
/run/pdns                                 5B
/run/pdns-recursor                        0
/run/pdns/pdns.pid                        5B
/run/pdns_recursor.pid                    5B
/run/pihole                               0
/run/pihole-FTL.pid                       4B
/tmp/dnsmasq_warnings                     8K
/var/lib/powerdns/pdns.sqlite3            80K
/var/lib/powerdns/pdns.sqlite3-shm        32K
/var/lib/powerdns/pdns.sqlite3-wal        0
/var/log/pihole                           908.3K
/var/log/pihole/FTL.log                   889.1K
/var/log/pihole/pihole.log                19.2K

These entries have been changed between ftl_base_x86_64_full and ftl_base_x86_64_no_ftl:
FILE                               SIZE1         SIZE2
/var/log/lastlog                   285.4K        29.4K
/var/log/faillog                   31.3K         3.2K
/etc/passwd                        1.1K          1K
/etc/powerdns/recursor.conf        1K            14.4K
/etc/passwd-                       1K            1019B
/etc/powerdns/pdns.conf            660B          19.3K
/etc/shadow                        581B          553B
/etc/group                         484B          469B
/etc/group-                        469B          457B
/etc/gshadow                       402B          391B
/etc/gshadow-                      391B          382B
/etc/subgid                        20B           0
/etc/subuid                        20B           0

```

This PR separates the build from the test part by:
1) Using a multi stage build, where testing is a different target than building (the image)
2) Adjusting the GH action workflow to build the image completely (including the testing layer) but pushes only the building target when a new release is tagged

There should be difference when building the images locally, as by default all targets are build.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
