### PR TITLE
Remove Mini-GMP from x86_64 builds

### DIFF
--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -62,7 +62,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
-    && ./configure --enable-static --disable-shared --enable-mini-gmp \
+    && ./configure --enable-static --disable-shared \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -76,7 +76,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
-    && ./configure --enable-static --disable-shared --enable-mini-gmp \
+    && ./configure --enable-static --disable-shared \
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Remove Mini-GMP from x86_64 builds. We build the other binaries with full GMP so no need to make an exception here


- **How does this PR accomplish the above?:**

Remove `--enable-mini-gmp` during `nettle` configuring


- **What documentation changes (if any) are needed to support this PR?:**

None


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [X] I have read the above and my PR is ready for review. _Check this box to confirm_
