### PR TITLE
Add x86-64_full capability

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ARCH: [aarch64, armv4t, armv5te, armv6hf,armv7hf,armv8a,x86_32,x86_64,x86_64-musl]
+        ARCH: [aarch64, armv4t, armv5te, armv6hf, armv7hf, armv8a, x86_32, x86_64, x86_64-musl]
     steps:
       -
         name: Checkout Repo
@@ -71,6 +71,16 @@ jobs:
           # Caching disabled for now...
           # cache-from: type=gha,scope=${{ matrix.ARCH }}
           # cache-to: type=gha,scope=${{ matrix.ARCH }},mode=max
+      -
+        name: Build (all-in)
+        if: ${{ matrix.ARCH }} == 'x86_64'
+        uses: docker/build-push-action@v3
+        with:
+          context: ftl-build/${{ matrix.ARCH }}/.
+          push: false
+          target: tester-all-in
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
       -
         name: Push
         if: github.event_name != 'pull_request'

--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -73,7 +73,7 @@ jobs:
           # cache-to: type=gha,scope=${{ matrix.ARCH }},mode=max
       -
         name: Build (all-in)
-        if: ${{ matrix.ARCH }} == 'x86_64'
+        if: matrix.ARCH == 'x86_64'
         uses: docker/build-push-action@v3
         with:
           context: ftl-build/${{ matrix.ARCH }}/.

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -47,7 +47,8 @@ RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-46 main" 
 
 # Wget the pdns-backend-sqlite3.deb and install it
 RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb; \
-    dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
+    dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb && \
+    rm pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
 
 ENV CC "gcc -m32"
 RUN ln -s /usr/lib32/libm.so /usr/local/lib/

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -136,6 +136,7 @@ ENV BATS=/bats-core/bin/bats
 FROM builder AS all-in-compilation
 
 # For FTL test compilation
+# Setting `CI_ARCH` to `x86_64_full` will trigger a compilation with extensive compiler options enabled within the makefile 
 ARG CI_ARCH="x86_64_full"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -133,7 +133,7 @@ RUN git clone https://github.com/bats-core/bats-core.git \
 
 ENV BATS=/bats-core/bin/bats
 
-FROM builder AS all-in-compilation
+FROM builder AS tester-all-in
 
 # For FTL test compilation
 # Setting `CI_ARCH` to `x86_64_full` will trigger a compilation with extensive compiler options enabled within the makefile 
@@ -148,6 +148,7 @@ RUN git clone https://github.com/pi-hole/FTL.git \
     && cd FTL \
     && git checkout "${GIT_BRANCH}" \
     && bash build.sh "-DSTATIC=${STATIC}" \
+    && bash test/arch_test.sh \
     && bash test/run.sh \
     && cd .. \
     && rm -r FTL

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -4,6 +4,11 @@ ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 ARG nettleversion=3.8.1
+ARG libmnlversion=1.0.5
+ARG libnftnlversion=1.2.3
+ARG nftablesversion=1.0.5
+ARG libnfnetlinkversion=1.0.2
+ARG libnetfilter_conntrackversion=1.0.9
 
 # We need a more recent dnsutils version for native HTTPS and SVCB support in dig
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list \
@@ -30,6 +35,10 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
         gnupg \
         psmisc \
         git \
+        bzip2 \
+        # dnsmasq all-options dependencies below
+        libdbus-1-dev \
+        pkg-config \
     && apt-get -t buster-backports install --no-install-recommends -y \
         dnsutils \
     && rm -rf /var/lib/apt/lists/*
@@ -41,11 +50,13 @@ RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian buster-auth-46 main" 
     echo "Pin-Priority: 600" >> /etc/apt/preferences.d/pdns && \
     curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - && \
     apt-get update && \
-    apt-get install pdns-server pdns-recursor -y
+    apt-get install pdns-server pdns-recursor -y && \
+    rm -rf /var/lib/apt/lists/*
 
-# Wget the pdns-backend-sqlite3.deb and install it
+# Download the pdns-backend-sqlite3.deb and install it
 RUN wget https://repo.powerdns.com/debian/pool/main/p/pdns/pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb && \
-    dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
+    dpkg -i pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb && \
+    rm pdns-backend-sqlite3_4.6.3-1pdns.buster_amd64.deb
 
 ENV CC gcc
 
@@ -81,11 +92,64 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
     && cd .. \
     && rm -r nettle-${nettleversion}
 
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libmnl-${libmnlversion}.tar.bz2 | tar -xj \
+    && cd libmnl-${libmnlversion} \
+    && ./configure --disable-dependency-tracking \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libmnl-${libmnlversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libnftnl-${libnftnlversion}.tar.bz2 | tar -xj \
+    && cd libnftnl-${libnftnlversion} \
+    && ./configure --disable-dependency-tracking \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libnftnl-${libnftnlversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nftables-${nftablesversion}.tar.bz2 | tar -xj \
+    && cd nftables-${nftablesversion} \
+    && ./configure --without-cli --disable-dependency-tracking --disable-man-doc \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r nftables-${nftablesversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libnfnetlink-${libnfnetlinkversion}.tar.bz2 | tar -xj \
+    && cd libnfnetlink-${libnfnetlinkversion} \
+    && ./configure --disable-dependency-tracking \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libnfnetlink-${libnfnetlinkversion}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libnetfilter_conntrack-${libnetfilter_conntrackversion}.tar.bz2 | tar -xj \
+    && cd libnetfilter_conntrack-${libnetfilter_conntrackversion} \
+    && ./configure --disable-dependency-tracking \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libnetfilter_conntrack-${libnetfilter_conntrackversion}
+
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core
 
 ENV BATS=/bats-core/bin/bats
+
+FROM builder AS all-in-compilation
+
+# For FTL test compilation
+ARG CI_ARCH="x86_64_full"
+ARG GIT_TAG="test-build"
+ARG GIT_BRANCH="special/CI_development"
+
+# Test compile FTL's development branch, the result is removed from the final container
+# We accept errors in the arch_test step to be able to update the arch_tests if a change is intended
+# Run the full test suite to ensure that the container is still capable of running the tests
+RUN git clone https://github.com/pi-hole/FTL.git \
+    && cd FTL \
+    && git checkout "${GIT_BRANCH}" \
+    && bash build.sh "-DSTATIC=${STATIC}" \
+    && bash test/run.sh \
+    && cd .. \
+    && rm -r FTL
 
 FROM builder AS tester
 


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

Allow building a (nearly) all-options build of `dnsmasq`

**How does this PR accomplish the above?:**

Add remaining dependencies. We skip `i18n` and `ubus` as the former strongly depends on the user's system and makes nearly no difference code-wise (one macro is re-defined). `ubus` is only natively available on OpenWRT systems and not easily installable on any other distributions.

The `x86_64` container needs more time for building now as it has an additional stage to build such a full `dnsmasq` build *in addition* to the regular build. Both binaries are tested.

**Link documentation PRs if any are needed to support this PR:**

None

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
