### PR TITLE
Update alpine container and use archive for Debian stretch

### DIFF
--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -7,6 +7,12 @@ ARG termcapversion=1.3.1
 ARG nettleversion=3.8.1
 ARG mbedtlsversion=3.4.0
 
+# Switch repositories to the archive server
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/stretch-updates/d' /etc/apt/sources.list \
+    && echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN dpkg --add-architecture armel \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -37,7 +43,7 @@ RUN dpkg --add-architecture armel \
 
 # Github actions/Checkout@v2 requires git >=2.18 else it will fall back to github API to download tarball
 # stretch-backports also has dnsutils 9.11.5, which has support for +unknown (See https://github.com/pi-hole/FTL/pull/1223#discussion_r731148277)
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
+RUN echo "deb http://archive.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list \
     && apt-get update \
     && apt-get -t stretch-backports install --no-install-recommends -y \
         git \

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VER=3.17
+ARG ALPINE_VER=3.18
 FROM alpine:${ALPINE_VER} AS builder
 
 ARG idnversion=1.41


### PR DESCRIPTION
# What does this implement/fix?

### Part 1: Update alpine container v3.17 -> v3.18

Highlights are the updated Linux kernel [6.1](https://kernelnewbies.org/Linux_6.1) with signed kernel modules initial support for the Rust programming language.

Furthermore, the updated musl libc [1.2.4](https://www.openwall.com/lists/musl/2023/05/02/1) now with TCP fallback in the DNS resolver, fixing the longstanding inability to query large DNS records and some more DNS-related improvements.

There is an interesting change in Alpine that all packages for ppc64le, x86, and x86_64 are now linked with [DT_RELR](https://maskray.me/blog/2021-10-31-relative-relocations-and-relr). This reduces the size of compiled binaries (practically everything shrinks 5-8% in size), however, it also makes them runtime-dependent on `libmusl`. FTL is *not* affected as our set of link-time flags will still produce `pihole-FTL` as static-linked [PIE](https://en.wikipedia.org/wiki/Position-independent_code) binaries which, as always, is self-contained and has no such dependency.


### Part 2: Debian Stretch is no longer available via standard repos, switch to archive

This change is necessary to still be able to build Debian Stretch based containers, see [here](http://archive.debian.org/debian/dists/stretch/). Switching to the archive servers is necessary as of end of March this year, however, we did not try to build new containers meanwhile so this shows up only now.



**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.