### PR TITLE
Update libnettle to latest version (v3.9)

### DIFF
--- a/ftl-build/aarch64/Dockerfile
+++ b/ftl-build/aarch64/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 RUN dpkg --add-architecture arm64 \

--- a/ftl-build/armv4t/Dockerfile
+++ b/ftl-build/armv4t/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stretch AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 # Switch repositories to the archive server

--- a/ftl-build/armv7hf/Dockerfile
+++ b/ftl-build/armv7hf/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 RUN dpkg --add-architecture armhf \

--- a/ftl-build/armv8a/Dockerfile
+++ b/ftl-build/armv8a/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 RUN dpkg --add-architecture armhf \

--- a/ftl-build/riscv64/Dockerfile
+++ b/ftl-build/riscv64/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:sid AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 RUN apt-get update \

--- a/ftl-build/x86_32/Dockerfile
+++ b/ftl-build/x86_32/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 # We need a more recent dnsutils version for native HTTPS and SVCB support in dig

--- a/ftl-build/x86_64-musl/Dockerfile
+++ b/ftl-build/x86_64-musl/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:${ALPINE_VER} AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG mbedtlsversion=3.4.0
 
 RUN apk add --no-cache \

--- a/ftl-build/x86_64/Dockerfile
+++ b/ftl-build/x86_64/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.8.1
+ARG nettleversion=3.9
 ARG libmnlversion=1.0.5
 ARG libnftnlversion=1.2.3
 ARG nftablesversion=1.0.5


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

Update `nettle` to the latest version release two weeks ago.

Pi-hole benefits from better performance, a few bug fixes and a new password hash (Balloon) which is a candidate for how Pi-hole v6.0 securely stores the user password.

## NEWS for the Nettle 3.9 release

This release includes bug fixes, several new features, a few
performance improvements, and one performance regression
affecting GCM on certain platforms.

The new version is intended to be fully source and binary
compatible with Nettle-3.6. The shared library names are
libnettle.so.8.7 and libhogweed.so.6.7, with sonames
libnettle.so.8 and libhogweed.so.6.

This release includes a rewrite of the C implementation of
GHASH (dating from 2011), as well as the plain x86_64 assembly
version, to use precomputed tables in a different way, with
tables always accessed in the same sequential manner.

This should make Nettle's GHASH implementation side-channel
silent on all platforms, but considerably slower on platforms
without carry-less mul instructions. E.g., benchmarks of the C
implementation on x86_64 showed a slowdown of 3 times.

Bug fixes:

* Fix bug in ecdsa and gostdsa signature verify operation, for
  the unlikely corner case that point addition really is point
  duplication.

* Fix for chacha on Power7, nettle's assembly used an
  instruction only available on later processors. Fixed by
  Mamone Tarsha.

* GHASH implementation should now be side-channel silent on
  all architectures.

* A few portability fixes for *BSD.

New features:

* Support for the SM4 block cipher, contributed by Tianjia Zhang.

* Support for the Balloon password hash, contributed by Zoltan Fridrich.

* Support for SIV-GCM authenticated encryption mode, contributed by Daiki Ueno.

* Support for OCB authenticated encryption mode.

* New exported functions md5_compress, sha1_compress,
  sha256_compress, sha512_compress, based on patches from
  Corentin Labbe.

Optimizations:

* Improved sha256 performance, in particular for x86_64 and
  s390x.

* Use GMP's mpn_sec_tabselect, which is implemented in
  assembly on many platforms, and delete the similar nettle
  function. Gives a modest speedup to all ecc operations.

* Faster poly1305 for x86_64 and ppc64. New ppc code
  contributed by Mamone Tarsha.

Miscellaneous:

* New ASM_FLAGS variable recognized by configure.

* Delete all arcfour assembly code. Affects 32-bit x86, 32-bit
  and 64-bit sparc.

Known issues:

* Version 6.2.1 of GNU GMP (the most recent GMP release as of
  this writing) has a known issue for MacOS on 64-bit ARM: GMP
  assembly files use the reserved x18 register. On this
  platform it is recommended to use a GMP snapshot where this
  bug is fixed, and upgrade to a later GMP release when one
  becomes available.

* Also on MacOS, Nettle's testsuite may still break due to
  DYLD_LIBRARY_PATH being discarded under some circumstances.
  As a workaround, use

  make check EMULATOR='env DYLD_LIBRARY_PATH=$(TEST_SHLIB_DIR)'

**How does this PR accomplish the above?:**

Update the version to be compiled in the containers

**Link documentation PRs if any are needed to support this PR:**

None

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
