### PR TITLE
Fix broken FTL build process for PRs

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -1,14 +1,11 @@
 name: ftl-build builds
 on:
+  pull_request:
+    paths:
+      - 'ftl-build/**'
+      - '.github/workflows/ftl-build.yml'
   push:
-    # Run on all branches and tags, but only if the ftl-build directory or the
-    # workflow itself changed. This is to avoid running the workflow on
-    # unrelated changes.
-    # Note that including the branch filter is necessary as otherwise (paths and tags alone),
-    # the workflow would not run on pushes to branches that do not have a tag sticked to them.
     tags:
-      - "**"
-    branches:
       - "**"
     paths:
       - 'ftl-build/**'

--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -95,6 +95,7 @@ jobs:
             CONTAINER=${{ matrix.container }}
       -
         name: Push builder target and push by digest (Docker Hub)
+        if: github.event_name != 'pull_request'
         id: build_docker
         uses: docker/build-push-action@v4
         with:
@@ -109,6 +110,7 @@ jobs:
             type=image,name=${{ env.DOCKER_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       -
         name: Push builder target and push by digest (GitHub Container Registry)
+        if: github.event_name != 'pull_request'
         id: build_ghcr
         uses: docker/build-push-action@v4
         with:
@@ -123,6 +125,7 @@ jobs:
             type=image,name=${{ env.GITHUB_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       -
         name: Export digests
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests/dockerhub/${{ env.context }}
           mkdir -p /tmp/digests/ghcr/${{ env.context }}
@@ -132,6 +135,7 @@ jobs:
           touch "/tmp/digests/ghcr/${{ env.context }}/${digest_ghcr#sha256:}"
       -
         name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: digests
@@ -143,6 +147,7 @@ jobs:
   # If we would push immediately above, the individual runners would overwrite each other's images
   # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   merge-and-deploy:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs:
       - build-and-test


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

As far as I can see, the dependabot PRs are falling over because they are attempting to login to and push images to docker hub / ghcr. This should not happen, and could have disastrous consequences 

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_