### PR TITLE
Update nettle 3.9 -> 3.9.1 and mbedtls 3.4.0 -> 3.4.1

### DIFF
--- a/ftl-build/alpine/Dockerfile
+++ b/ftl-build/alpine/Dockerfile
@@ -4,8 +4,8 @@ FROM ${CONTAINER} AS builder
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.9
-ARG mbedtlsversion=3.4.0
+ARG nettleversion=3.9.1
+ARG mbedtlsversion=3.4.1
 
 RUN apk add --no-cache \
         alpine-sdk \

--- a/ftl-build/debian/Dockerfile
+++ b/ftl-build/debian/Dockerfile
@@ -6,8 +6,8 @@ ARG CONTAINER
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
-ARG nettleversion=3.9
-ARG mbedtlsversion=3.4.0
+ARG nettleversion=3.9.1
+ARG mbedtlsversion=3.4.1
 
 # Switch repositories to the archive server
 RUN if [ "${CONTAINER}" = "debian:stretch-slim" ]; then \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

See title.

[`nettle` CHANGELOG](https://lists.gnu.org/archive/html/info-gnu/2023-06/msg00000.html):

```
NEWS for the Nettle 3.9.1 release

        This is a bugfix release, fixing a few bugs reported for
        Nettle-3.9. The bug in the new OCB code may be exploitable for
        denial of service or worse, since triggering it leads to
        memory corruption. Upgrading from Nettle-3.9 to the new
        version is strongly recommended.

        The new version is intended to be fully source and binary
        compatible with Nettle-3.6. The shared library names are
        libnettle.so.8.8 and libhogweed.so.6.8, with sonames
        libnettle.so.8 and libhogweed.so.6.

        Bug fixes:

        * Fix OCB loop for processing messages of size 272 bytes or
          larger. Reported and fixed by Jussi Kivilinna.

        * Fix alignment bug in the new x86_64 non-pclmul assembly
          implementation of ghash. Reported by Henrik Grubbström.

        * Fix build-time memory leak in eccdata. Reported by Noah
          Watkins.
```

[`libmbedtls` CHANGELOG](https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.4.1):

> # Description
> 
> This release of Mbed TLS provides bug fixes and minor enhancements.
> # Security Advisories
>
> There are no security advisories for this release.
> # Who should update
>
> We recommend all users should update to take advantage of the bug fixes contained in this release at an appropriate point in their development lifecycle.

There [really isn't much going on](https://github.com/Mbed-TLS/mbedtls/compare/v3.4.0...v3.4.1) here, but it also doesn't hurt to stay up-to-date.