### PR TITLE
Add libunwind into the container

### DIFF
--- a/ftl-build/alpine/Dockerfile
+++ b/ftl-build/alpine/Dockerfile
@@ -7,7 +7,6 @@ ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
 ARG mbedtlsversion=3.4.1
-ARG libunwindversion=1.6.2
 
 RUN apk add --no-cache \
         alpine-sdk \
@@ -29,6 +28,8 @@ RUN apk add --no-cache \
         py3-yaml \
         zip \
         py3-requests \
+        libunwind-static \
+        libunwind-dev \
         perl
 
 # Install pdns from community repo
@@ -83,22 +84,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.gz
     && make -j $(nproc) install \
     && cd .. \
     && rm -r mbedtls-${mbedtlsversion}
-
-# Build static libunwind (we cannot use the Alpine package because it depends on
-# xz and possibly other libraries)
-# If $TARGETPLATFORM is "linux/386", we need to build libunwind for
-# i586-linux-musl. This is necessary because otherwise, libunwind's configure
-# script fails to detect we are in a buildx environment and tries to built for
-# x86_64 which ultimately fails because several x86_64-specific registers are
-# not available in the i386 build environment.
-RUN if [ "$TARGETPLATFORM" != "linux/386" ]; then \
-       curl -sSL https://ftl.pi-hole.net/libraries/libunwind-${libunwindversion}.tar.gz | tar -xz \
-    && cd libunwind-${libunwindversion} \
-    && ./configure --enable-static --disable-shared --disable-tests --disable-documentation \
-    && make -j $(nproc) install \
-    && cd .. \
-    && rm -rf libunwind-${libunwindversion}; \
-    fi
 
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git

--- a/ftl-build/alpine/Dockerfile
+++ b/ftl-build/alpine/Dockerfile
@@ -1,11 +1,13 @@
 ARG CONTAINER="alpine:edge"
 FROM ${CONTAINER} AS builder
+ARG TARGETPLATFORM
 
 ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
 ARG mbedtlsversion=3.4.1
+ARG libunwindversion=1.6.2
 
 RUN apk add --no-cache \
         alpine-sdk \
@@ -81,6 +83,22 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.gz
     && make -j $(nproc) install \
     && cd .. \
     && rm -r mbedtls-${mbedtlsversion}
+
+# Build static libunwind (we cannot use the Alpine package because it depends on
+# xz and possibly other libraries)
+# If $TARGETPLATFORM is "linux/386", we need to build libunwind for
+# i586-linux-musl. This is necessary because otherwise, libunwind's configure
+# script fails to detect we are in a buildx environment and tries to built for
+# x86_64 which ultimately fails because several x86_64-specific registers are
+# not available in the i386 build environment.
+RUN if [ "$TARGETPLATFORM" != "linux/386" ]; then \
+       curl -sSL https://ftl.pi-hole.net/libraries/libunwind-${libunwindversion}.tar.gz | tar -xz \
+    && cd libunwind-${libunwindversion} \
+    && ./configure --enable-static --disable-shared --disable-tests --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -rf libunwind-${libunwindversion}; \
+    fi
 
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git

--- a/ftl-build/alpine/Dockerfile
+++ b/ftl-build/alpine/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache \
         py3-requests \
         libunwind-static \
         libunwind-dev \
+        xz-static \
         perl
 
 # Install pdns from community repo

--- a/ftl-build/debian/Dockerfile
+++ b/ftl-build/debian/Dockerfile
@@ -8,6 +8,7 @@ ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
 ARG mbedtlsversion=3.4.1
+ARG libunwindversion=1.6.2
 
 # Switch repositories to the archive server
 RUN if [ "${CONTAINER}" = "debian:stretch-slim" ]; then \
@@ -86,6 +87,14 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.gz
     && make -j $(nproc) install \
     && cd .. \
     && rm -rf mbedtls-${mbedtlsversion}
+
+# Build static libunwind
+RUN curl -sSL https://ftl.pi-hole.net/libraries/libunwind-${libunwindversion}.tar.gz | tar -xz \
+    && cd libunwind-${libunwindversion} \
+    && ./configure --enable-static --disable-shared --disable-tests --disable-documentation \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -rf libunwind-${libunwindversion}
 
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git


### PR DESCRIPTION
# What does this implement/fix?

Add `libunwind` into the container. The primary goal of `libunwind` is to define a portable and efficient C programming interface (API) to determine the call-chain of a program to restore the ability to generate callbacks on application crashes. We "lost" this ability when switching to `musl`-based build environments.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.