### PR TITLE
Add libbacktrace into ftl-build container

### DIFF
--- a/ftl-build/alpine/Dockerfile
+++ b/ftl-build/alpine/Dockerfile
@@ -82,6 +82,14 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.gz
     && cd .. \
     && rm -r mbedtls-${mbedtlsversion}
 
+# Build static libbacktrace
+RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
+    && cd libbacktrace \
+    && ./configure --enable-static --disable-shared \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libbacktrace
+
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git
 

--- a/ftl-build/debian/Dockerfile
+++ b/ftl-build/debian/Dockerfile
@@ -87,6 +87,14 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.gz
     && cd .. \
     && rm -rf mbedtls-${mbedtlsversion}
 
+# Build static libbacktrace
+RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
+    && cd libbacktrace \
+    && ./configure --enable-static --disable-shared \
+    && make -j $(nproc) install \
+    && cd .. \
+    && rm -r libbacktrace
+
 # Install bats-core directly into the build image
 RUN git clone https://github.com/bats-core/bats-core.git
 


### PR DESCRIPTION
# What does this implement/fix?

See title, to be used by future FTL builds.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.