### PR TITLE
Add libidn2, remove libidn

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -2,7 +2,6 @@ ARG CONTAINER="alpine:edge"
 FROM ${CONTAINER} AS builder
 
 ARG TARGETPLATFORM
-ARG idnversion=1.41
 ARG readlineversion=8.1
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
@@ -28,6 +27,10 @@ RUN apk add --no-cache \
         py3-yaml \
         zip \
         py3-requests \
+        libidn2-dev \
+        libidn2-static \
+        libunistring-dev \
+        libunistring-static \
         perl
 
 # Install pdns from community repo
@@ -41,13 +44,6 @@ RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VER}/communi
 
 ENV STATIC true
 ENV TEST true
-
-RUN curl -sSL https://ftl.pi-hole.net/libraries/libidn-${idnversion}.tar.gz | tar -xz \
-    && cd libidn-${idnversion} \
-    && ./configure --enable-static --disable-shared --disable-doc --disable-valgrind-tests \
-    && make -j $(nproc) install \
-    && cd .. \
-    && rm -r libidn-${idnversion}
 
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \


### PR DESCRIPTION
# What does this implement/fix?

Remove self-compiled `libidn` and, instead, use `libidn2` as provided by Alpine itself

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.