### PR TITLE
Update bundled libreadline from 8.1 to 8.2

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -2,7 +2,7 @@ ARG CONTAINER="alpine:edge"
 FROM ${CONTAINER} AS builder
 
 ARG TARGETPLATFORM
-ARG readlineversion=8.1
+ARG readlineversion=8.2
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
 ARG mbedtlsversion=3.5.0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*


---


`libreadline` CHANGELOG:
> This document details the changes between this version, readline-8.2, and
> the previous version, readline-8.1.
> 
> 1. Changes to Readline
> 
>    a. Fixed a problem with cleaning up active marks when using callback mode.
> 
>    b. Fixed a problem with arithmetic comparison operators checking the version.
> 
>    c. Fixed a problem that could cause readline not to build on systems without
>    POSIX signal functions.
> 
>    d. Fixed a bug that could cause readline to crash if the application removed
>    the callback line handler before readline read all typeahead.
> 
>    e. Added additional checks for read errors in the middle of readline commands.
> 
>    f. Fixed a redisplay problem that occurred when switching from the digit-
>    argument prompt `(arg: N)' back to the regular prompt and the regular
>    prompt contained invisible characters.
> 
>    g. Fixed a problem with restoring the prompt when aborting an incremental
>    search.
> 
>    h. Fix a problem with characters > 128 not being displayed correctly in certain
>    single-byte encodings.
> 
>    i. Fixed a problem with unix-filename-rubout that caused it to delete too much
>    when applied to a pathname consisting only of one or more slashes.
> 
>    j. Fixed a display problem that caused the prompt to be wrapped incorrectly if
>    the screen changed dimensions during a call to readline() and the prompt
>    became longer than the screen width.
> 
>    k. Fixed a problem that caused the \r output by turning off bracketed paste
>    to overwrite the line if terminal echo was disabled.
> 
>    l. Fixed a bug that could cause colored-completion-prefix to not display if
>    completion-prefix-display-length was set.
> 
>    m. Fixed a problem with line wrapping prompts when a group of invisible
>    characters runs to the right edge of the screen and the prompt extends
>    longer then the screen width.
> 
>    n. Fixed a couple problems that could cause rl_end to be set incorrectly by
>    transpose-words.
> 
>    o. Prevent some display problems when running a command as the result of a
>    trap or one bound using `bind -x' and the command generates output.
> 
>    p. Fixed an issue with multi-line prompt strings that have one or more
>    invisible characters at the end of a physical line.
> 
>    q. Fixed an issue that caused a history line's undo list to be cleared when
>    it should not have been.
> 
>    r. When replacing a history entry, make sure the existing entry has a non-NULL
>    timestamp before copying it; it may have been added by the application, not
>    the history library.
> 
> 2. New Features in Readline
> 
>    a. There is now an HS_HISTORY_VERSION containing the version number of the
>    history library for applications to use.
> 
>    b. History expansion better understands multiple history expansions that may
>    contain strings that would ordinarily inhibit history expansion (e.g.,
>    `abc!$!$').
> 
>    c. There is a new framework for readline timeouts, including new public
>    functions to set timeouts and query how much time is remaining before a
>    timeout hits, and a hook function that can trigger when readline times
>    out. There is a new state value to indicate a timeout.
> 
>    d. Automatically bind termcap key sequences for page-up and page-down to
>    history-search-backward and history-search-forward, respectively.
> 
>    e. There is a new `fetch-history' bindable command that retrieves the history
>    entry corresponding to its numeric argument. Negative arguments count back
>    from the end of the history.
> 
>    f. `vi-undo' is now a bindable command.
> 
>    g. There is a new option: `enable-active-region'. This separates control of
>    the active region and bracketed-paste. It has the same default value as
>    bracketed-paste, and enabling bracketed paste enables the active region.
>    Users can now turn off the active region while leaving bracketed paste
>    enabled.
> 
>    h. rl_completer_word_break_characters is now `const char *' like
>    rl_basic_word_break_characters.
> 
>    i. Readline looks in $LS_COLORS for a custom filename extension
>    (*.readline-colored-completion-prefix) and uses that as the default color
>    for the common prefix displayed when `colored-completion-prefix' is set.
> 
>    j. Two new bindable string variables: active-region-start-color and
>    active-region-end-color. The first sets the color used to display the
>    active region; the second turns it off. If set, these are used in place
>    of terminal standout mode.
> 
>    k. New readline state (RL_STATE_EOF) and application-visible variable
>    (rl_eof_found) to allow applications to detect when readline reads EOF
>    before calling the deprep-terminal hook.
> 
>    l. There is a new configuration option: --with-shared-termcap-library, which
>    forces linking the shared readline library with the shared termcap (or
>    curses/ncurses/termlib) library so applications don't have to do it.
> 
>    m. Readline now checks for changes to locale settings (LC_ALL/LC_CTYPE/LANG)
>    each time it is called, and modifies the appropriate locale-specific display
>    and key binding variables when the locale changes.
