### PR TITLE
Update mbedtls from 3.5.0 to 3.6.1

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -85,8 +85,6 @@ jobs:
           target: tester
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            CONTAINER=alpine:${{ ( github.event_name == 'scheduled' || matrix.platform == 'linux/riscv64' ) && 'edge' || 'latest' }}
       -
         name: Push builder target and push by digest
         if: github.event_name != 'pull_request'
@@ -98,8 +96,6 @@ jobs:
           push: ${{ github.event_name != 'workflow_dispatch' }}
           target: builder
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            CONTAINER=alpine:${{ ( github.event_name == 'scheduled' || matrix.platform == 'linux/riscv64' ) && 'edge' || 'latest' }}
           outputs: |
             type=image,name=${{ env.DOCKER_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
             type=image,name=${{ env.GITHUB_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -98,6 +98,8 @@ jobs:
           push: ${{ github.event_name != 'workflow_dispatch' }}
           target: builder
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CONTAINER=alpine:${{ ( github.event_name == 'scheduled' || matrix.platform == 'linux/riscv64' ) && 'edge' || 'latest' }}
           outputs: |
             type=image,name=${{ env.DOCKER_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
             type=image,name=${{ env.GITHUB_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 ARG readlineversion=8.2
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
-ARG mbedtlsversion=3.5.0
+ARG mbedtlsversion=3.6.1
 
 RUN apk add --no-cache \
         alpine-sdk \
@@ -37,7 +37,9 @@ RUN apk add --no-cache \
         pdns-backend-sqlite3 \
         pdns-recursor \
         pdns-doc \
-        gdb
+        gdb \
+        py3-jinja2 \
+        py3-jsonschema
 
 ENV STATIC true
 ENV TEST true
@@ -70,7 +72,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
 # Build static mbedTLS with pthread support
 # Disable AESNI on linux/386 asit would possibly result in an incompatible
 # binary in processors lacking the AESNI and SSE2 instruction sets
-RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.gz | tar -xz \
+RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz2 | tar -xj \
     && cd mbedtls-${mbedtlsversion} \
     && sed -i '/#define MBEDTLS_THREADING_C/s*^//**g' include/mbedtls/mbedtls_config.h \
     && sed -i '/#define MBEDTLS_THREADING_PTHREAD/s*^//**g' include/mbedtls/mbedtls_config.h \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -1,4 +1,4 @@
-ARG CONTAINER="alpine:edge"
+ARG CONTAINER="alpine:latest"
 FROM ${CONTAINER} AS builder
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
# What does this implement/fix?

See title.

The respective CHANGELOGs can be found on their pages, I'm only quoting security-related changes here:

- https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.5.1 (Nov 8, 2023)
  No real change happened in this point release
- https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.5.2 (Jan 26, 2024)
  
  -  Fix a timing side channel in private key RSA operations. This side channel
    could be sufficient for an attacker to recover the plaintext. A local
    attacker or a remote attacker who is close to the victim on the network
    might have precise enough timing measurements to exploit this. It requires
    the attacker to send a large number of messages for decryption. For
    details, see "Everlasting ROBOT: the Marvin Attack", Hubert Kario. Reported
    by Hubert Kario, Red Hat.
  -  Fix a failure to validate input when writing x509 extensions lengths which
    could result in an integer overflow, causing a zero-length buffer to be
    allocated to hold the extension. The extension would then be copied into
    the buffer, causing a heap buffer overflow.

- https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.6.0 (Mar 28, 2024)
  - This release of Mbed TLS provides new features, bug fixes and minor enhancements. This release includes fixes for security issues. **This release brings in improved multithreaded operations, record-size-limit, and early-data support and other TLS1.3 improvements. TLS1.3 support is now enabled by default.**
  - Fix a stack buffer overread (less than 256 bytes) when parsing a TLS 1.3
    ClientHello in a TLS 1.3 server supporting some PSK key exchange mode. A
    malicious client could cause information disclosure or a denial of service.
    Passing buffers that are stored in untrusted memory as arguments
    to PSA functions is now secure by default.
  - The PSA core now protects against modification of inputs or exposure
    of intermediate outputs during operations. This is currently implemented
    by copying buffers.
    This feature increases code size and memory usage. If buffers passed to
    PSA functions are owned exclusively by the PSA core for the duration of
    the function call (i.e. no buffer parameters are in shared memory),
    copying may be disabled by setting MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS.
    Note that setting this option will cause input-output buffer overlap to
    be only partially supported (https://github.com/Mbed-TLS/mbedtls/issues/3266).
    Fixes https://github.com/advisories/GHSA-6h48-8w2f-5w94.
  -  Restore the maximum TLS version to be negotiated to the configured one
    when an SSL context is reset with the mbedtls_ssl_session_reset() API.
    An attacker was able to prevent an Mbed TLS server from establishing any
    TLS 1.3 connection potentially resulting in a Denial of Service or forced
    version downgrade from TLS 1.3 to TLS 1.2. Fixes https://github.com/Mbed-TLS/mbedtls/issues/8654 reported by hey3e.
    Fixes https://github.com/advisories/GHSA-9w5c-29mx-552c.
   - When negotiating TLS version on server side, do not fall back to the
    TLS 1.2 implementation of the protocol if it is disabled.
      -  If the TLS 1.2 implementation was disabled at build time, a TLS 1.2
        client could put the TLS 1.3-only server in an infinite loop processing
        a TLS 1.2 ClientHello, resulting in a denial of service. Reported by
        Matthias Mucha and Thomas Blattmann, SICK AG.
      -  If the TLS 1.2 implementation was disabled at runtime, a TLS 1.2 client
        was able to successfully establish a TLS 1.2 connection with the server.
        Reported by alluettiv on GitHub.
        Fixes https://github.com/advisories/GHSA-39fv-p94v-rg6c.
- https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1 (today)

  -  Unlike previously documented, enabling MBEDTLS_PSA_HMAC_DRBG_MD_TYPE does
    not cause the PSA subsystem to use HMAC_DRBG: it uses HMAC_DRBG only when
    MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG and MBEDTLS_CTR_DRBG_C are disabled.
    CVE-2024-45157
   - Fix a stack buffer overflow in mbedtls_ecdsa_der_to_raw() and
    mbedtls_ecdsa_raw_to_der() when the bits parameter is larger than the
    largest supported curve. In some configurations with PSA disabled,
    all values of bits are affected. This never happens in internal library
    calls, but can affect applications that call these functions directly.
    CVE-2024-45158
   - With TLS 1.3, when a server enables optional authentication of the
    client, if the client-provided certificate does not have appropriate values
    in keyUsage or extKeyUsage extensions, then the return value of
    mbedtls_ssl_get_verify_result() would incorrectly have the
    MBEDTLS_X509_BADCERT_KEY_USAGE and MBEDTLS_X509_BADCERT_EXT_KEY_USAGE bits
    clear. As a result, an attacker that had a certificate valid for uses other
    than TLS client authentication could be able to use it for TLS client
    authentication anyway. Only TLS 1.3 servers were affected, and only with
    optional authentication (required would abort the handshake with a fatal
    alert).
    CVE-2024-45159

This PR furthermore ends the special magic that ensures `riscv64` is built using `alpine:edge` while the others are all built on `alpine:latest` as `riscv64` is [officially supported](https://alpinelinux.org/posts/Alpine-3.20.0-released.html) since Alpine Linux release v3.20.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.