### PR TITLE
Use mbedTLS 3.6.2 released a few days ago (Oct 15, 2024)

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 ARG readlineversion=8.2
 ARG termcapversion=1.3.1
 ARG nettleversion=3.9.1
-ARG mbedtlsversion=3.6.1
+ARG mbedtlsversion=3.6.2
 
 RUN apk add --no-cache \
         alpine-sdk \


### PR DESCRIPTION
# What does this implement/fix?

See title. Quoting from https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.2:

> This release of Mbed TLS provides the fix for a security vulnerability.
> 
> Mbed TLS 3.6 is a long-term support (LTS) branch. It will be supported with bug-fixes and security fixes until at least March 2027.
>
> - Fix a buffer underrun in mbedtls_pk_write_key_der() when
>   called on an opaque key, MBEDTLS_USE_PSA_CRYPTO is enabled,
>   and the output buffer is smaller than the actual output.
> - Fix a related buffer underrun in mbedtls_pk_write_key_pem()
>   when called on an opaque RSA key, MBEDTLS_USE_PSA_CRYPTO is enabled
>   and MBEDTLS_MPI_MAX_SIZE is smaller than needed for a 4096-bit RSA key.
>   CVE-2024-49195

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.