### PR TITLE
Update libnettle to recently relesed 3.10.1

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -4,7 +4,7 @@ FROM ${CONTAINER} AS builder
 ARG TARGETPLATFORM
 ARG readlineversion=8.2
 ARG termcapversion=1.3.1
-ARG nettleversion=3.9.1
+ARG nettleversion=3.10.1
 ARG mbedtlsversion=3.6.2
 
 RUN apk add --no-cache \


### PR DESCRIPTION
# What does this implement/fix?

Somehow we missed to update to 3.10 in between. The changelog is rather long and there is nothing outstanding for us, most work seems to have gone into the testing suite, e.g., related to side-channel testing in the ECC code.

Highlights from the CHANGELOG:
- Don't reorder the subkeys during aes_invert
- Optimize powerpc64 aes decrypt. Speedup of 80%-100%, depending on key size, when benchmarked on Power 10
- Fix CPU feature detection on Apple M1
- RSA-OAEP support
- Support elf_aux_info (OpenBSD and FreeBSD)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.