### PR TITLE
Don't push images when build from forks

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -3,20 +3,7 @@ on:
   push:
     branches:
       - '**'
-    paths:
-      - 'ftl-build/**'
-      - '.github/workflows/ftl-build.yml'
-    tags:
-      - '**'
-    # Only run on push events to the main repository (not from forks)
   pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'ftl-build/**'
-      - '.github/workflows/ftl-build.yml'
-    # Only run on PRs from forks
-    branches:
-      - '**'
   workflow_dispatch:
   schedule:
     # 1:30am UTC every Sunday, has no particular significance
@@ -27,10 +14,28 @@ env:
   GITHUB_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/ftl-build
 
 jobs:
-  build-and-test:
+  smoke-tests:
     if: |
-      (github.event_name == 'push' && github.repository == 'pi-hole/docker-base-images') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+      || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'schedule'
+
+    outputs:
+      DO_DEPLOY: ${{ steps.variables.outputs.DO_DEPLOY }}
+    runs-on: ubuntu-latest
+    steps:
+      -         
+        name: "Calculate required variables"
+        id: variables
+        run: |
+          echo "DO_DEPLOY=${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_PASS != '' && github.actor != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
+
+
+  build-and-test:
+    needs: smoke-tests
+    env:
+      DO_DEPLOY: ${{ needs.smoke-tests.outputs.DO_DEPLOY }}
     strategy:
       fail-fast: false
       matrix:
@@ -71,6 +76,7 @@ jobs:
             type=ref,event=branch,enable=${{ github.event_name != 'schedule' }}
       -
         name: Login to Docker Hub
+        if: env.DO_DEPLOY == 'true'
         uses: docker/login-action@v2
         with:
           registry: docker.io
@@ -79,6 +85,7 @@ jobs:
 
       -
         name: Login to GitHub Container Registry
+        if: env.DO_DEPLOY == 'true'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -106,7 +113,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       -
         name: Push builder target and push by digest
-        if: github.event_name != 'pull_request'
+        if: env.DO_DEPLOY == 'true'
         id: build_docker
         uses: docker/build-push-action@v6
         with:
@@ -120,14 +127,14 @@ jobs:
             type=image,name=${{ env.GITHUB_REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       -
         name: Export digests
-        if: github.event_name != 'pull_request'
+        if: env.DO_DEPLOY == 'true'
         run: |
           mkdir -p /tmp/digests/
           digest_docker="${{ steps.build_docker.outputs.digest }}"
           touch "/tmp/digests/${digest_docker#sha256:}"
       -
         name: Upload digest
-        if: github.event_name != 'pull_request'
+        if: env.DO_DEPLOY == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -139,10 +146,11 @@ jobs:
   # If we would push immediately above, the individual runners would overwrite each other's images
   # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   merge-and-deploy:
-    if: github.event_name != 'pull_request'
+    if: needs.smoke-tests.outputs.DO_DEPLOY == 'true'
     runs-on: ubuntu-latest
     needs:
       - build-and-test
+      - smoke-tests
     steps:
       -
         name: Checkout Repo


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Do not try to login to the registries and push images when PRs come from forks. Uses the same logic as FTL does now.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
