### PR TITLE
Run build workflow on new tag

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - '**'
+    tags:
+      - '**'
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Re-adds workflow trigger `tag` which was accidentally removed by https://github.com/pi-hole/docker-base-images/pull/114