### PR TITLE
Split tags per registry in image merge step

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -205,9 +205,9 @@ jobs:
         name: Create manifest list and push to repository  DockerHub and GitHub Container Registry)
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create $(jq -cr '.tags | map(select(startswith("${{ env.GITHUB_REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.GITHUB_REGISTRY_IMAGE }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create $(jq -cr '.tags | map(select(startswith("${{ env.DOCKER_REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKER_REGISTRY_IMAGE }}@sha256:%s ' *)
       -
         name: Inspect images


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Same as https://github.com/pi-hole/docker-pi-hole/pull/2005.

After updating `buildx` to `0.31.1` our image merge workflow broke.

After a very good discussion [here](https://github.com/docker/buildx/issues/3708) with the maintainers of `buildx`, it turned out, that our workflow always just worked due to a bug.
During the discussion, a workaround was suggested by splitting the tags on per-registry basis. This is what this PR implements. This is based [on a suggestion ](https://github.com/crazy-max/docker-healthchecks/blob/eef77d758b6c8b06220adc3e4b4f11da1eca6a89/.github/workflows/build.yml#L188-L191)by crazy-max.

This supersedes https://github.com/pi-hole/docker-base-images/pull/140

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
