### PR TITLE
ftl-build: add static OpenSSL 3.5 LTS

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -5,6 +5,7 @@ ARG readlineversion=8.3
 ARG termcapversion=1.3.1-patched
 ARG nettleversion=3.10.2
 ARG mbedtlsversion=4.0.0
+ARG opensslversion=3.5.7
 ARG BATS_CORE_VER=v1.13.0
 ARG BATS_SUPPORT_VER=v0.3.0
 ARG BATS_ASSERT_VER=v2.2.4
@@ -95,6 +96,28 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
     && cmake --install build \
     && cd .. \
     && rm -r mbedtls-${mbedtlsversion}
+
+# Build static OpenSSL 3.5 LTS (TLS for civetweb + DoT/DoH, and native QUIC for
+# the future DoQ/DoH3 work).
+# Trimmed for binary size: drop the legacy provider, unused protocols/ciphers,
+# engines and DSO. QUIC stays enabled (default in 3.5). no-deprecated is left
+# off on purpose: it saves very little and would require a civetweb patch
+# (SSL_library_init, SSL_get_peer_certificate) to keep compiling.
+# TODO: pull from the ftl.pi-hole.net mirror (like the other libs) once the
+# tarball is uploaded there; using the upstream release directly for now.
+RUN curl -sSL https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz | tar -xz \
+    && cd openssl-${opensslversion} \
+    && ./config \
+        no-shared no-tests no-docs no-apps \
+        no-legacy no-comp no-dtls no-ssl3 \
+        no-psk no-srp no-idea no-rc2 no-rc4 no-rc5 no-md4 no-mdc2 no-whirlpool \
+        no-engine no-dso \
+        --prefix=/usr/local --libdir=lib --openssldir=/usr/local/ssl \
+    && make -j $(nproc) \
+    && make install_dev \
+    && ls -l /usr/local/lib/libssl.a /usr/local/lib/libcrypto.a \
+    && cd .. \
+    && rm -r openssl-${opensslversion}
 
 # Build static libbacktrace
 RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -103,8 +103,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
 # engines and DSO. QUIC stays enabled (default in 3.5). no-deprecated is left
 # off on purpose: it saves very little and would require a civetweb patch
 # (SSL_library_init, SSL_get_peer_certificate) to keep compiling.
-# TODO: pull from the ftl.pi-hole.net mirror (like the other libs) once the
-# tarball is uploaded there; using the upstream release directly for now.
 RUN curl -sSL https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz | tar -xz \
     && cd openssl-${opensslversion} \
     && ./config \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -117,7 +117,7 @@ RUN case "${TARGETPLATFORM}" in \
         "linux/riscv64") OSSL_TARGET="linux64-riscv64" ;; \
         *) echo "unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
     esac \
-    && curl -sSL https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz | tar -xz \
+    && curl -sSL https://ftl.pi-hole.net/libraries/openssl-${opensslversion}.tar.gz | tar -xz \
     && cd openssl-${opensslversion} \
     && ./Configure "${OSSL_TARGET}" \
         no-shared no-tests no-docs no-apps \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -170,7 +170,7 @@ RUN sed -i '/buffer_with_truncation /d' /bats/bats-core/libexec/bats-core/bats-f
 # Run the full test suite to ensure that the container is still capable of running the tests
 RUN git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
     && cd FTL \
-    && bash build.sh "-DSTATIC=${STATIC}" \
+    && bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON" \
     && readelf -A ./pihole-FTL \
     && readelf -l ./pihole-FTL \
     && bash test/arch_test.sh \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -103,9 +103,23 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
 # engines and DSO. QUIC stays enabled (default in 3.5). no-deprecated is left
 # off on purpose: it saves very little and would require a civetweb patch
 # (SSL_library_init, SSL_get_peer_certificate) to keep compiling.
-RUN curl -sSL https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz | tar -xz \
+# Pick the OpenSSL target from TARGETPLATFORM: ./config guesses it from `uname`,
+# which is wrong whenever the container arch differs from the build host kernel
+# (386 on a 64-bit kernel, the 32-bit ARM variants on an arm64 runner, riscv64
+# under QEMU) and yields "64-bit mode not compiled in". Runtime CPU-feature
+# dispatch still handles AES-NI etc., so no further per-arch tuning is needed.
+RUN case "${TARGETPLATFORM}" in \
+        "linux/amd64")   OSSL_TARGET="linux-x86_64"    ;; \
+        "linux/386")     OSSL_TARGET="linux-x86"       ;; \
+        "linux/arm/v6")  OSSL_TARGET="linux-armv4"     ;; \
+        "linux/arm/v7")  OSSL_TARGET="linux-armv4"     ;; \
+        "linux/arm64")   OSSL_TARGET="linux-aarch64"   ;; \
+        "linux/riscv64") OSSL_TARGET="linux64-riscv64" ;; \
+        *) echo "unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac \
+    && curl -sSL https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz | tar -xz \
     && cd openssl-${opensslversion} \
-    && ./config \
+    && ./Configure "${OSSL_TARGET}" \
         no-shared no-tests no-docs no-apps \
         no-legacy no-comp no-dtls no-ssl3 \
         no-psk no-srp no-idea no-rc2 no-rc4 no-rc5 no-md4 no-mdc2 no-whirlpool \


### PR DESCRIPTION
## What

Adds a self-built, static **OpenSSL 3.5.7 (LTS)** to the `ftl-build` image,
alongside the existing crypto libraries. Built the same way as the other
vendored libs (version-pinned tarball from the mirror -> `./config` ->
`make install_dev`).

## Why

Build-side prerequisite for migrating FTL's TLS stack from mbedTLS to OpenSSL:

- **First-class support in CivetWeb.** CivetWeb 1.17 has a mature, upstream
  OpenSSL backend; its mbedTLS backend is the one that caused the 100% CPU
  busy-spin on non-blocking TLS sockets.
- **Native QUIC.** OpenSSL 3.5 ships QUIC client *and* server, which the planned
  DoQ / DoH3 work will build on. mbedTLS cannot do QUIC at all.

One TLS stack for everything (CivetWeb HTTPS, DoT/DoH client + server, and the
future QUIC paths) instead of pulling in a second library later.

## Build details

- **Static against musl** (`no-shared`), installed to `/usr/local/lib` where
  FTL's `find_library` looks (`--libdir=lib`).
- **Trimmed for binary size** (the shipped FTL is a musl-static binary): legacy
  provider, unused protocols/ciphers (`no-legacy no-comp no-dtls no-ssl3
  no-psk no-srp no-idea no-rc2 no-rc4 no-rc5 no-md4 no-mdc2 no-whirlpool`),
  and `no-engine no-dso no-apps no-tests no-docs`.
- **QUIC stays enabled** (default in 3.5).
- **No per-arch AES-NI special-casing** (unlike mbedTLS): OpenSSL selects its
  optimized code paths at runtime via CPU-capability detection, so the same
  recipe is safe on `linux/386` and the ARM targets.
- **`no-deprecated` deliberately left off.** It removes calls CivetWeb 1.17 still
  makes (`SSL_library_init`/`SSL_load_error_strings`, `SSL_get_peer_certificate`
  under `OPENSSL_API_3_0` + `NO_SSL_DL`), so it would need a CivetWeb patch to
  keep building - and the size gain (~150 KiB off the archives) is not worth it.

## mbedTLS kept for now

mbedTLS is deliberately left in place so the current FTL still builds (the
image's `test` stage compiles FTL). It will be removed in a follow-up, in
lockstep with the FTL-side TLS migration.

## Testing

Built the OpenSSL layer locally on the `alpine:3.24` base (amd64), using the
exact recipe/flags from this PR:

- `libcrypto.a` (~12.2 MB) and `libssl.a` (~2.1 MB) archives produced, no shared
  objects. (Archive sizes; `--gc-sections` prunes most of this at final link.)
- QUIC client + server symbols present: `OSSL_QUIC_client_method`,
  `OSSL_QUIC_server_method`, `SSL_new_listener`, `SSL_accept_connection`.
- musl-linked (built on the Alpine base).

Per-arch coverage (`linux/386`, `armv6/7`, `arm64`, `riscv64`) is left to this
repo's multi-arch CI build.
