### PR TITLE
ci: build on release, not on tag push

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '**'
   pull_request:
   workflow_dispatch:
   release:
@@ -52,6 +50,7 @@ jobs:
       - smoke-tests
     permissions:
       contents: read # same as global permissions
+      id-token: write # sign the GHA cache; build-and-push (which also has id-token) requires signed cache entries and rebuilds from scratch without this
     with:
       setup-qemu: true
       cache: true


### PR DESCRIPTION
## Summary

- **Trigger on `release: published` instead of tag push** — matches the convention used by FTL, docker-pi-hole and the rest of the sub-repos. Tag pushes and release publishes happen together, so having both triggers meant every release ran the entire pipeline twice.
- **Give `build-and-test` `id-token: write`** — `docker/github-builder` only signs its GHA cache export when the calling job has an OIDC token, and only *requires* a signature on import when the calling job has one too. `build-and-test` was writing unsigned cache, `build-and-push` demanded signed, so it silently rebuilt every layer from scratch instead of reusing the cache (buried at debug level: `missing signature for github actions cache`).

Net effect on the v2.20 release: four full riscv64 builds of the same commit and a ~2.5 hour pipeline. This should get that down to one cold build plus a quick cached re-export.