### PR TITLE
ci: stop publishing :nightly, keep branch-tag testing

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -37,7 +37,7 @@ jobs:
         name: "Calculate required variables"
         id: variables
         run: |
-          echo "DO_DEPLOY=${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_PASS != '' && github.actor != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
+          echo "DO_DEPLOY=${{ (github.event_name == 'release' || (github.event_name != 'pull_request' && github.ref != 'refs/heads/master')) && secrets.DOCKERHUB_PASS != '' && github.actor != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
 
       # FIXME: can't use env object in reusable workflow inputs: https://github.com/orgs/community/discussions/26671
       -
@@ -89,15 +89,10 @@ jobs:
       meta-images: |
         ${{ needs.smoke-tests.outputs.DOCKER_REGISTRY_IMAGE }}
         ${{ needs.smoke-tests.outputs.GITHUB_REGISTRY_IMAGE }}
-      # meta-tags:
-        # type=schedule, pattern=nightly means that a "nightly" tag is applied when the workflow is triggered by a schedule event
-        # type=raw,value=nightly means that a "nightly" tag is applied when the workflow is triggerd by a push to a branch (enabled only for master branch to avoid tagging every push to other branches with "nightly")
-        # type=ref,event=branch means that a tag is applied when the workflow is triggered by a push to a branch (enabled only for non-master branches to avoid tagging every push to master branch with the branch name)
-        # type=ref,event=tag means that a tag is applied when the workflow is triggered by a push to a tag
+      # master never reaches build-and-push (see DO_DEPLOY), so no nightly tag is needed:
+      # branch pushes get tagged with the branch name, releases get the tag name
       meta-tags: |
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/master' }}
-            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master' }}
+            type=ref,event=branch
             type=ref,event=tag
       meta-flavor: |
         latest=${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
## Summary

- **`master` pushes no longer publish images** (`build-and-push` no longer runs for them, dropping the `nightly` tag). Nothing consumes it: FTL's own build container pins `ghcr.io/pi-hole/ftl-build:v2.19` (a release tag), not `:nightly`, and there's no other known consumer. Every master push was doing a full multi-arch build-and-push for nothing, alongside the equivalent build-and-test run moments earlier, doubling CI time and cache-quota pressure.
- **Branch-tag publishing is unchanged.** Pushes to any other branch still run `build-and-push` and publish under the branch name, since those images are genuinely used to test a build before cutting a release.
- Releases are unaffected either way.

`build-and-test` is untouched and still runs (build + test, no push) on every push, PR, and the weekly schedule, so validation coverage is unchanged.

(Earlier version of this PR dropped branch-tag publishing entirely — turns out those are actually used for pre-release testing, so this revision keeps that and only drops the unused `nightly` tag.)