### PR TITLE
ci: single-pass build & publish, multi-stage ftl-build Dockerfile

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -44,13 +44,27 @@ jobs:
         name: "Expose registry variables for reusable workflow"
         run: echo "Exposing env vars for reusable workflow"
 
+  # Build and test the toolchain (target: test, which extends target: build with a
+  # full FTL clone/compile/test cycle to prove the toolchain works), then publish
+  # that same image when DO_DEPLOY is true. This used to be two jobs: a push: false
+  # build-and-test, and a separate build-and-push that rebuilt target: build from
+  # scratch to publish, relying on importing cache the first job wrote seconds
+  # earlier. GitHub's cache signing is too slow for that same-run handoff, so the
+  # push job silently rebuilt everything anyway. Building once and conditionally
+  # pushing the result avoids the handoff entirely.
+  #
+  # The published image is the test target, so it keeps ENV TARGETPLATFORM and the
+  # inert leftover state from the FTL test run (the checkout is removed, but files
+  # build.sh/run.sh write elsewhere are not). Harmless for a build harness: nothing
+  # in FTL's build reads it, and run.sh recreates its own state on each use.
   build-and-test:
     uses: docker/github-builder/.github/workflows/build.yml@3415a188caae9a0da7fba83bc06985776e0b1790 #v1.14.0
     needs:
       - smoke-tests
     permissions:
       contents: read # same as global permissions
-      id-token: write # sign the GHA cache; build-and-push (which also has id-token) requires signed cache entries and rebuilds from scratch without this
+      id-token: write # sign the GHA cache, and sign attestations when pushing
+      packages: write # required to push to GHCR when DO_DEPLOY
     with:
       setup-qemu: true
       cache: true
@@ -61,39 +75,15 @@ jobs:
       output: image
       target: test
       platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
-      push: false
-      meta-images: |
-        ${{ needs.smoke-tests.outputs.DOCKER_REGISTRY_IMAGE }}
-        ${{ needs.smoke-tests.outputs.GITHUB_REGISTRY_IMAGE }}
-
-  build-and-push:
-    if: needs.smoke-tests.outputs.DO_DEPLOY == 'true'
-    needs:  [smoke-tests, build-and-test]
-    uses: docker/github-builder/.github/workflows/build.yml@3415a188caae9a0da7fba83bc06985776e0b1790 #v1.14.0
-    permissions:
-      contents: read # same as global permissions
-      id-token: write # for signing attestation(s) with GitHub OIDC Token
-      packages: write # required to push to GHCR
-    with:
-      setup-qemu: true
-      cache: true
-      cache-scope: build
-      cache-mode: max
-      context: ftl-build
-      fail-fast: true
-      output: image
-      target: build
-      platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
-      push: true
+      push: ${{ needs.smoke-tests.outputs.DO_DEPLOY == 'true' }}
       set-meta-labels: true
       meta-images: |
         ${{ needs.smoke-tests.outputs.DOCKER_REGISTRY_IMAGE }}
         ${{ needs.smoke-tests.outputs.GITHUB_REGISTRY_IMAGE }}
-      # meta-tags:
-        # type=schedule, pattern=nightly means that a "nightly" tag is applied when the workflow is triggered by a schedule event
-        # type=raw,value=nightly means that a "nightly" tag is applied when the workflow is triggerd by a push to a branch (enabled only for master branch to avoid tagging every push to other branches with "nightly")
-        # type=ref,event=branch means that a tag is applied when the workflow is triggered by a push to a branch (enabled only for non-master branches to avoid tagging every push to master branch with the branch name)
-        # type=ref,event=tag means that a tag is applied when the workflow is triggered by a push to a tag
+      # type=schedule,pattern=nightly      -> "nightly" on the weekly scheduled run
+      # type=raw,value=nightly (master)    -> "nightly" on pushes to master
+      # type=ref,event=branch (non-master) -> the branch name on pushes to other branches
+      # type=ref,event=tag                 -> the tag on a release
       meta-tags: |
             type=schedule,pattern=nightly
             type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -75,6 +75,10 @@ jobs:
       output: image
       target: test
       platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
+      # unique per run (and per re-run attempt) so the FTL build/test layer is never
+      # served from cache - it must re-validate against current FTL every time
+      build-args: |
+        CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
       push: ${{ needs.smoke-tests.outputs.DO_DEPLOY == 'true' }}
       set-meta-labels: true
       meta-images: |

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -196,8 +196,13 @@ ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # Run the full test suite to ensure that the container is still capable of running the tests
-# Ensure that the TERM environment variable is set for BATS color output
-RUN git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
+# CACHEBUST is fed a per-run value so this layer never comes from cache: it is a
+# validation gate, not a build artifact, and must re-test against current FTL every
+# time (a cache hit here would silently skip building/testing FTL entirely).
+# TERM is set for BATS colour output during the test run.
+ARG CACHEBUST
+RUN echo "Validating toolchain against FTL (build ${CACHEBUST})" \
+    && git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
     && cd FTL \
     && bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON" \
     && readelf -A ./pihole-FTL \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -1,6 +1,3 @@
-FROM alpine:3.24 AS build
-
-ARG TARGETPLATFORM
 ARG readlineversion=8.3
 ARG termcapversion=1.3.1-patched
 ARG nettleversion=3.10.2
@@ -11,7 +8,15 @@ ARG BATS_SUPPORT_VER=v0.3.0
 ARG BATS_ASSERT_VER=v2.2.4
 ARG BATS_FILE_VER=v0.4.0
 
-RUN apk add --no-cache \
+FROM alpine:3.24 AS base
+
+# apk uses a BuildKit cache mount instead of --no-cache so downloaded packages are
+# reused across builds rather than bloating the layer. Intentional tradeoff: without
+# --no-cache the index is no longer force-refreshed each build, so package versions
+# can go stale between cache-mount evictions. Acceptable for a build toolchain pinned
+# to a specific alpine tag.
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add \
         alpine-sdk \
         bash \
         bind-tools \
@@ -49,11 +54,10 @@ RUN apk add --no-cache \
         xxd \
         zip
 
-ENV STATIC=true
-ENV TEST=true
-
 # As of Alpine 3.21 (Dec 2024), we need to patch the termcap library to include
 # the standard headers as well as unistd.h for the write function
+FROM base AS termcap-build
+ARG termcapversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
     && ./configure --enable-static --disable-shared --disable-doc --without-examples \
@@ -64,6 +68,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
     && cd .. \
     && rm -r termcap-${termcapversion}
 
+FROM base AS readline-build
+ARG readlineversion
+COPY --from=termcap-build /usr/local/ /usr/local/
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
     && ./configure --enable-static --disable-shared --disable-install-examples \
@@ -73,6 +80,8 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
+FROM base AS nettle-build
+ARG nettleversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
     && ./configure --enable-static --disable-shared --disable-openssl --disable-mini-gmp -disable-gcov --disable-documentation \
@@ -83,6 +92,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
 # Build static mbedTLS with pthread support
 # Disable AESNI on linux/386 asit would possibly result in an incompatible
 # binary in processors lacking the AESNI and SSE2 instruction sets
+FROM base AS mbedtls-build
+ARG TARGETPLATFORM
+ARG mbedtlsversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz2 | tar -xj \
     && cd mbedtls-${mbedtlsversion} \
     && sed -i '/#define MBEDTLS_THREADING_C/s*^//**g' tf-psa-crypto/include/psa/crypto_config.h \
@@ -108,6 +120,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
 # (386 on a 64-bit kernel, the 32-bit ARM variants on an arm64 runner, riscv64
 # under QEMU) and yields "64-bit mode not compiled in". Runtime CPU-feature
 # dispatch still handles AES-NI etc., so no further per-arch tuning is needed.
+FROM base AS openssl-build
+ARG TARGETPLATFORM
+ARG opensslversion
 RUN case "${TARGETPLATFORM}" in \
         "linux/amd64")   OSSL_TARGET="linux-x86_64"    ;; \
         "linux/386")     OSSL_TARGET="linux-x86"       ;; \
@@ -132,6 +147,7 @@ RUN case "${TARGETPLATFORM}" in \
     && rm -r openssl-${opensslversion}
 
 # Build static libbacktrace
+FROM base AS libbacktrace-build
 RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
     && cd libbacktrace \
     && ./configure --enable-static --disable-shared \
@@ -139,11 +155,31 @@ RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
     && cd .. \
     && rm -r libbacktrace
 
-# Install bats-core directly into the build image
+# Install bats-core, plus the bats-support/bats-assert/bats-file helper
+# libraries FTL's test suite loads via BATS_LIB_PATH
+FROM base AS bats-build
+ARG BATS_CORE_VER
+ARG BATS_SUPPORT_VER
+ARG BATS_ASSERT_VER
+ARG BATS_FILE_VER
 RUN git clone --depth=1 --single-branch --branch "${BATS_CORE_VER}" https://github.com/bats-core/bats-core.git /bats/bats-core \
   && git clone --depth=1 --single-branch --branch "${BATS_SUPPORT_VER}" https://github.com/bats-core/bats-support /bats/bats-support \
   && git clone --depth=1 --single-branch --branch "${BATS_ASSERT_VER}" https://github.com/bats-core/bats-assert  /bats/bats-assert \
   && git clone --depth=1 --single-branch --branch "${BATS_FILE_VER}" https://github.com/bats-core/bats-file    /bats/bats-file
+
+FROM base AS build
+
+ENV STATIC=true
+ENV TEST=true
+
+COPY --link --from=termcap-build /usr/local/ /usr/local/
+COPY --link --from=readline-build /usr/local/ /usr/local/
+COPY --link --from=nettle-build /usr/local/ /usr/local/
+COPY --link --from=mbedtls-build /usr/local/ /usr/local/
+COPY --link --from=openssl-build /usr/local/ /usr/local/
+COPY --link --from=libbacktrace-build /usr/local/ /usr/local/
+COPY --link --from=bats-build /bats /bats
+
 ENV BATS=/bats/bats-core/bin/bats
 ENV BATS_LIB_PATH=/bats/
 
@@ -157,7 +193,6 @@ ARG TARGETVARIANT
 ARG CI_ARCH="$TARGETPLATFORM"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
-
 
 # Test compile FTL's development branch, the result is removed from the final container
 # Run the full test suite to ensure that the container is still capable of running the tests


### PR DESCRIPTION
## Summary

- **Build, test and publish in a single job.** `build-and-push` is merged into `build-and-test`, so the toolchain is built once (as `target: test`, which runs the full FTL clone/build/test cycle) and that same image is pushed when `DO_DEPLOY` is true, rather than being rebuilt as `target: build` in a second job just to publish. Nightly, branch and release tagging are unchanged.
- **Multi-stage Dockerfile.** The single build stage is split into isolated per-library stages (termcap, readline, nettle, mbedTLS, openssl, libbacktrace, bats) derived from a shared `base` and assembled with `COPY --link`, so a version bump to one library only invalidates that stage and its copy layer instead of every layer after it. `apk` uses a BuildKit cache mount instead of `--no-cache`. Multi-stage approach from #162.
- **Never cache the FTL build/test layer.** The test stage clones, builds and tests FTL to prove the toolchain still works. As a plain `RUN` it would be served from cache whenever the toolchain layers are unchanged, silently skipping the test; a per-run `CACHEBUST` build-arg forces just that layer to re-run every build while the toolchain stays cached.