### PR TITLE
ftl-build: upgrade to OpenSSL 4.0, add nghttp2, nghttp3 and ngtcp2

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -40,6 +40,7 @@ RUN apk add --no-cache \
         pdns-doc \
         pdns-recursor \
         perl \
+        py3-aioquic \
         py3-dnspython \
         py3-jinja2 \
         py3-jsonschema \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -5,7 +5,10 @@ ARG readlineversion=8.3
 ARG termcapversion=1.3.1-patched
 ARG nettleversion=3.10.2
 ARG mbedtlsversion=4.0.0
-ARG opensslversion=3.5.7
+ARG opensslversion=4.0.0
+ARG nghttp2version=1.69.0
+ARG nghttp3version=1.17.0
+ARG ngtcp2version=1.24.0
 ARG BATS_CORE_VER=v1.14.0
 ARG BATS_SUPPORT_VER=v0.3.0
 ARG BATS_ASSERT_VER=v2.2.4
@@ -97,12 +100,14 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
     && cd .. \
     && rm -r mbedtls-${mbedtlsversion}
 
-# Build static OpenSSL 3.5 LTS (TLS for civetweb + DoT/DoH, and native QUIC for
-# the future DoQ/DoH3 work).
-# Trimmed for binary size: drop the legacy provider, unused protocols/ciphers,
-# engines and DSO. QUIC stays enabled (default in 3.5). no-deprecated is left
-# off on purpose: it saves very little and would require a civetweb patch
-# (SSL_library_init, SSL_get_peer_certificate) to keep compiling.
+# Build static OpenSSL 4.0 (TLS for civetweb + DoT/DoH, and native QUIC plus the
+# SSL_get_peer_addr API the future DoQ/DoH3 work needs).
+# Trimmed for binary size: drop the legacy provider, unused protocols/ciphers
+# and DSO. QUIC stays enabled (default since 3.5). no-deprecated is left off on
+# purpose: it saves very little and would require a civetweb patch
+# (SSL_library_init, SSL_get_peer_certificate) to keep compiling. no-ssl3 /
+# no-engine are not passed: SSLv3 and the ENGINE API are already gone in 4.0, so
+# both are only accepted as deprecated Configure options.
 # Pick the OpenSSL target from TARGETPLATFORM: ./config guesses it from `uname`,
 # which is wrong whenever the container arch differs from the build host kernel
 # (386 on a 64-bit kernel, the 32-bit ARM variants on an arm64 runner, riscv64
@@ -121,15 +126,43 @@ RUN case "${TARGETPLATFORM}" in \
     && cd openssl-${opensslversion} \
     && ./Configure "${OSSL_TARGET}" \
         no-shared no-tests no-docs no-apps \
-        no-legacy no-comp no-dtls no-ssl3 \
+        no-legacy no-comp no-dtls \
         no-psk no-srp no-idea no-rc2 no-rc4 no-rc5 no-md4 no-mdc2 no-whirlpool \
-        no-engine no-dso \
+        no-dso \
         --prefix=/usr/local --libdir=lib --openssldir=/usr/local/ssl \
     && make -j $(nproc) \
     && make install_dev \
     && ls -l /usr/local/lib/libssl.a /usr/local/lib/libcrypto.a \
     && cd .. \
     && rm -r openssl-${opensslversion}
+
+# Static HTTP/2, HTTP/3 and QUIC libraries. Library-only builds
+# (--enable-lib-only) to drop the apps and their extra dependencies.
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nghttp2-${nghttp2version}.tar.gz | tar -xz \
+    && cd nghttp2-${nghttp2version} \
+    && ./configure --enable-lib-only --enable-static --disable-shared \
+    && make -j $(nproc) install \
+    && ls -l /usr/local/lib/libnghttp2.a \
+    && cd .. \
+    && rm -r nghttp2-${nghttp2version}
+
+RUN curl -sSL https://ftl.pi-hole.net/libraries/nghttp3-${nghttp3version}.tar.gz | tar -xz \
+    && cd nghttp3-${nghttp3version} \
+    && ./configure --enable-lib-only --enable-static --disable-shared \
+    && make -j $(nproc) install \
+    && ls -l /usr/local/lib/libnghttp3.a \
+    && cd .. \
+    && rm -r nghttp3-${nghttp3version}
+
+# ngtcp2 after OpenSSL: --with-openssl builds the "ossl" crypto backend
+# (libngtcp2_crypto_ossl) against the static OpenSSL 4.0 above.
+RUN curl -sSL https://ftl.pi-hole.net/libraries/ngtcp2-${ngtcp2version}.tar.gz | tar -xz \
+    && cd ngtcp2-${ngtcp2version} \
+    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-lib-only --enable-static --disable-shared --with-openssl \
+    && make -j $(nproc) install \
+    && ls -l /usr/local/lib/libngtcp2.a /usr/local/lib/libngtcp2_crypto_ossl.a \
+    && cd .. \
+    && rm -r ngtcp2-${ngtcp2version}
 
 # Build static libbacktrace
 RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \


### PR DESCRIPTION
# What does this implement/fix?

Three additions the upcoming encrypted-DNS and HTTP/2/3 work needs from the build image.

**OpenSSL 3.5 -> 4.0.0.** We jump straight to 4.0 rather than ship 3.5 and migrate again shortly after: 4.0 provides `SSL_get_peer_addr` natively, which has turned out to be essential for the later DoQ work needing to map a QUIC connection back to a client. `no-ssl3` and `no-engine` are dropped from `Configure` as they are gone in 4.0. THe target is now picked from `TARGETPLATFORM` instead of letting `./config` guess it from `uname`, which is wrong whenever the container arch differs from the build-host kernel (e.g., `386` on a 64-bit kernel, or the 32-bit ARM variants on an arm64 runner).
The full reasoning for going to 4.0 is in [this comment](https://github.com/pi-hole/docker-base-images/pull/167#issuecomment-5048223358) on the PR that initially added OpenSSL 3.5.

**Add `nghttp2`, `nghttp3` and `ngtcp2`.** These mature, small, and fast HTTP/2, HTTP/3 and QUIC libraries (the ones `curl` and others use as well) for the in-process terminator that will front CivetWeb - civetweb's own HTTP/2 is still experimental and does no HTTP/3 or QUIC at all. All three are `--enable-lib-only` static builds to avoid extra dependencies. `ngtcp2` is built after OpenSSL so its `ossl` crypto backend (`libngtcp2_crypto_ossl`) uses OpenSSL's native QUIC TLS API. We add it now, ahead of DoQ/DoH3, so the image is ready when that work lands; the three together are only ~0.6 MB, and static linking pulls in just what FTL actually references (`ngtcp2` only once DoQ links it). They will be needed in upcoming work:
1. Add HTTP/2 and HTTP/3 to the existing DoT/DoH server feature as well as the webserver
2. Add DoT/DoH2/DoH3 client feature (client -> Pi-hole FTL)
3. Add full native DoQ (incl. DoQ3) server + client extension.

**`py3-aioquic`.** A small Python QUIC/HTTP3 client, added so the DoH3 (HTTP/3) upstream test can run in CI. This is a dependency only needed for the CI tests, still no python at runtime needed.

## How to test the change during review

Build the `build` stage and confirm the static archives are produced:

```
cd ftl-build
docker buildx build --platform linux/amd64 --target build -t ftl-build:test .
docker run --rm ftl-build:test sh -c 'ls -l /usr/local/lib/libssl.a /usr/local/lib/libnghttp2.a /usr/local/lib/libnghttp3.a /usr/local/lib/libngtcp2.a /usr/local/lib/libngtcp2_crypto_ossl.a'
```

Each step already `ls -l`s its archive as it installs, so a green build proves OpenSSL 4.0 and the libraries compiled, and the CI matrix builds the image for every supported platform (amd64, 386, arm/v6, arm/v7, arm64, riscv64), exercising the per-arch OpenSSL target.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `master` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
