### PR TITLE
ftl-build: drop mbedTLS

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -4,7 +4,6 @@ ARG TARGETPLATFORM
 ARG readlineversion=8.3
 ARG termcapversion=1.3.1-patched
 ARG nettleversion=3.10.2
-ARG mbedtlsversion=4.0.0
 ARG opensslversion=4.0.0
 ARG nghttp2version=1.69.0
 ARG nghttp3version=1.17.0
@@ -83,23 +82,6 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
     && make -j $(nproc) install \
     && cd .. \
     && rm -r nettle-${nettleversion}
-
-# Build static mbedTLS with pthread support
-# Disable AESNI on linux/386 asit would possibly result in an incompatible
-# binary in processors lacking the AESNI and SSE2 instruction sets
-RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz2 | tar -xj \
-    && cd mbedtls-${mbedtlsversion} \
-    && sed -i '/#define MBEDTLS_THREADING_C/s*^//**g' tf-psa-crypto/include/psa/crypto_config.h \
-    && sed -i '/#define MBEDTLS_THREADING_PTHREAD/s*^//**g' tf-psa-crypto/include/psa/crypto_config.h \
-    && ( [ "${TARGETPLATFORM}" = "linux/386" ] \
-         && echo "BUILDING WITHOUT AESNI SUPPORT" \
-         && sed -i '/#define MBEDTLS_AESNI_C/s*^*//*g' include/mbedtls/mbedtls_config.h \
-         || echo "BUILDING WITH AESNI SUPPORT" ) \
-    && cmake -S . -B build -DCMAKE_C_FLAGS="-fomit-frame-pointer" \
-    && cmake --build build -j $(nproc) \
-    && cmake --install build \
-    && cd .. \
-    && rm -r mbedtls-${mbedtlsversion}
 
 # Build static OpenSSL 4.0 (TLS for civetweb + DoT/DoH, and native QUIC plus the
 # SSL_get_peer_addr API the future DoQ/DoH3 work needs).


### PR DESCRIPTION
FTL moved its webserver TLS stack from mbedTLS to OpenSSL ([pi-hole/FTL@de87e1456](https://github.com/pi-hole/FTL/commit/de87e1456)), so nothing links against mbedTLS anymore. The library was still built into the `ftl-build` image but is now unused. This removes the mbedTLS build step and its `mbedtlsversion` ARG, cutting a dependency and shrinking the image.

Safe with respect to the still-mbedTLS `master` branch of FTL: each FTL branch pins a specific `ftl-build` tag (master -> `v2.19`, development -> `v2.23`). Only the OpenSSL-based `development` line tracks new images, so master keeps building against the earlier tag that still ships mbedTLS. This is not a breaking change for any branch in use.

Independent of the other in-flight `ftl-build` PRs (#177) - they touch different lines and can merge in any order.