### PR TITLE
ci: build and test in a single pass

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -79,6 +79,10 @@ jobs:
       output: image
       target: test
       platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
+      # unique per run (and per re-run attempt) so the FTL build/test layer is never
+      # served from cache - it must re-validate against current FTL every time
+      build-args: |
+        CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
       push: ${{ needs.smoke-tests.outputs.DO_DEPLOY == 'true' }}
       set-meta-labels: true
       meta-images: |

--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -44,9 +44,7 @@ jobs:
         name: "Expose registry variables for reusable workflow"
         run: echo "Exposing env vars for reusable workflow"
 
-  # Build and test the toolchain (target: test, which extends target: build with a
-  # full FTL clone/compile/test cycle to prove the toolchain works), then publish
-  # that same image when DO_DEPLOY is true.
+  # Build and test the toolchain, then publish it when DO_DEPLOY is true.
   #
   # This used to be two jobs: a push: false build-and-test, and a separate
   # build-and-push that rebuilt target: build to publish, importing the cache the
@@ -54,13 +52,18 @@ jobs:
   # pass over all six platforms purely to re-materialise an image we had already
   # built, and it degrades to a full rebuild for any platform whose cache export
   # failed. One build, conditionally pushed, removes both the second pass and the
-  # dependency on the handoff, and makes the published image provably the one that
-  # was tested.
+  # dependency on the handoff.
   #
-  # The published image is the test target, so it keeps ENV TARGETPLATFORM and the
-  # inert leftover state from the FTL test run (the checkout is removed, but files
-  # build.sh/run.sh write elsewhere are not). Harmless for a build harness: nothing
-  # in FTL's build reads it, and run.sh recreates its own state on each use.
+  # target: publish is the toolchain as target: build produces it - the same image
+  # contents this workflow published before - and it depends on target: test, which
+  # runs the full FTL clone/compile/test cycle. So the test still gates the push,
+  # but the state that run.sh scatters across the filesystem stays in the discarded
+  # test stage instead of shipping to users. See ftl-build/Dockerfile.
+  #
+  # Note packages: write is now held for every run rather than only for deploys,
+  # since GitHub does not allow expressions in `permissions`. In practice this
+  # grants nothing extra: smoke-tests only runs pull_request for forks, whose
+  # GITHUB_TOKEN is read-only regardless.
   build-and-test:
     uses: docker/github-builder/.github/workflows/build.yml@3415a188caae9a0da7fba83bc06985776e0b1790 #v1.14.0
     needs:
@@ -77,7 +80,7 @@ jobs:
       context: ftl-build
       fail-fast: true
       output: image
-      target: test
+      target: publish
       platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
       # unique per run (and per re-run attempt) so the FTL build/test layer is never
       # served from cache - it must re-validate against current FTL every time

--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -44,13 +44,31 @@ jobs:
         name: "Expose registry variables for reusable workflow"
         run: echo "Exposing env vars for reusable workflow"
 
+  # Build and test the toolchain (target: test, which extends target: build with a
+  # full FTL clone/compile/test cycle to prove the toolchain works), then publish
+  # that same image when DO_DEPLOY is true.
+  #
+  # This used to be two jobs: a push: false build-and-test, and a separate
+  # build-and-push that rebuilt target: build to publish, importing the cache the
+  # first job had just written. That handoff generally works, but it costs a second
+  # pass over all six platforms purely to re-materialise an image we had already
+  # built, and it degrades to a full rebuild for any platform whose cache export
+  # failed. One build, conditionally pushed, removes both the second pass and the
+  # dependency on the handoff, and makes the published image provably the one that
+  # was tested.
+  #
+  # The published image is the test target, so it keeps ENV TARGETPLATFORM and the
+  # inert leftover state from the FTL test run (the checkout is removed, but files
+  # build.sh/run.sh write elsewhere are not). Harmless for a build harness: nothing
+  # in FTL's build reads it, and run.sh recreates its own state on each use.
   build-and-test:
     uses: docker/github-builder/.github/workflows/build.yml@3415a188caae9a0da7fba83bc06985776e0b1790 #v1.14.0
     needs:
       - smoke-tests
     permissions:
       contents: read # same as global permissions
-      id-token: write # sign the GHA cache; build-and-push (which also has id-token) requires signed cache entries and rebuilds from scratch without this
+      id-token: write # sign the GHA cache, and sign attestations when pushing
+      packages: write # required to push to GHCR when DO_DEPLOY
     with:
       setup-qemu: true
       cache: true
@@ -61,39 +79,15 @@ jobs:
       output: image
       target: test
       platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
-      push: false
-      meta-images: |
-        ${{ needs.smoke-tests.outputs.DOCKER_REGISTRY_IMAGE }}
-        ${{ needs.smoke-tests.outputs.GITHUB_REGISTRY_IMAGE }}
-
-  build-and-push:
-    if: needs.smoke-tests.outputs.DO_DEPLOY == 'true'
-    needs:  [smoke-tests, build-and-test]
-    uses: docker/github-builder/.github/workflows/build.yml@3415a188caae9a0da7fba83bc06985776e0b1790 #v1.14.0
-    permissions:
-      contents: read # same as global permissions
-      id-token: write # for signing attestation(s) with GitHub OIDC Token
-      packages: write # required to push to GHCR
-    with:
-      setup-qemu: true
-      cache: true
-      cache-scope: build
-      cache-mode: max
-      context: ftl-build
-      fail-fast: true
-      output: image
-      target: build
-      platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
-      push: true
+      push: ${{ needs.smoke-tests.outputs.DO_DEPLOY == 'true' }}
       set-meta-labels: true
       meta-images: |
         ${{ needs.smoke-tests.outputs.DOCKER_REGISTRY_IMAGE }}
         ${{ needs.smoke-tests.outputs.GITHUB_REGISTRY_IMAGE }}
-      # meta-tags:
-        # type=schedule, pattern=nightly means that a "nightly" tag is applied when the workflow is triggered by a schedule event
-        # type=raw,value=nightly means that a "nightly" tag is applied when the workflow is triggerd by a push to a branch (enabled only for master branch to avoid tagging every push to other branches with "nightly")
-        # type=ref,event=branch means that a tag is applied when the workflow is triggered by a push to a branch (enabled only for non-master branches to avoid tagging every push to master branch with the branch name)
-        # type=ref,event=tag means that a tag is applied when the workflow is triggered by a push to a tag
+      # type=schedule,pattern=nightly      -> "nightly" on the weekly scheduled run
+      # type=raw,value=nightly (master)    -> "nightly" on pushes to master
+      # type=ref,event=branch (non-master) -> the branch name on pushes to other branches
+      # type=ref,event=tag                 -> the tag on a release
       meta-tags: |
             type=schedule,pattern=nightly
             type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/master' }}

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -217,15 +217,15 @@ FROM base AS build
 ENV STATIC=true
 ENV TEST=true
 
-COPY --link --from=termcap-build /usr/local/ /usr/local/
-COPY --link --from=readline-build /usr/local/ /usr/local/
-COPY --link --from=nettle-build /usr/local/ /usr/local/
-COPY --link --from=mbedtls-build /usr/local/ /usr/local/
-COPY --link --from=openssl-build /usr/local/ /usr/local/
-COPY --link --from=nghttp2-build /usr/local/ /usr/local/
-COPY --link --from=nghttp3-build /usr/local/ /usr/local/
-COPY --link --from=ngtcp2-build /usr/local/ /usr/local/
-COPY --link --from=libbacktrace-build /usr/local/ /usr/local/
+COPY --link --parents --from=termcap-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=readline-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=nettle-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=mbedtls-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=openssl-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=nghttp2-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=nghttp3-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=ngtcp2-build /usr/local/lib /usr/local/include /
+COPY --link --parents --from=libbacktrace-build /usr/local/lib /usr/local/include /
 COPY --link --from=bats-build /bats /bats
 
 ENV BATS=/bats/bats-core/bin/bats

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -242,11 +242,18 @@ ARG CI_ARCH="$TARGETPLATFORM"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
 
-# Test compile FTL's development branch, the result is removed from the final container
-# Run the full test suite to ensure that the container is still capable of running the tests
-# CACHEBUST is fed a per-run value so this layer never comes from cache: it is a
-# validation gate, not a build artifact, and must re-test against current FTL every
-# time (a cache hit here would silently skip building/testing FTL entirely).
+# Compile FTL's development branch and run the full test suite, to prove the
+# toolchain can still build and test FTL. Nothing here is kept - this stage is a
+# gate, not an artifact - so the checkout and everything run.sh writes outside it
+# (/etc/pihole, /var/log/pihole, /etc/dnsmasq.d, /var/lib/powerdns, the pihole
+# user, ...) is simply left in place and discarded with the stage.
+#
+# Build this target directly to debug a failure locally: the FTL tree and all
+# logs survive for inspection.
+#
+# CACHEBUST is fed a per-run value so this layer never comes from cache - it must
+# re-validate against current FTL every time, and a cache hit here would silently
+# skip building and testing FTL entirely.
 # TERM is set for BATS colour output during the test run.
 ARG CACHEBUST
 RUN echo "Validating toolchain against FTL (build ${CACHEBUST})" \
@@ -258,4 +265,19 @@ RUN echo "Validating toolchain against FTL (build ${CACHEBUST})" \
     && bash test/arch_test.sh \
     && TERM=${TERM:-xterm} bash test/run.sh \
     && cd .. \
-    && rm -r FTL
+    && echo "${CACHEBUST}" > /toolchain-validated
+
+# The published image: the toolchain exactly as `build` produced it, with none of
+# the state the test run leaves behind.
+#
+# Dockerfiles have no way to say "this stage depends on that one", so the COPY is
+# what pulls `test` into the build graph - without it BuildKit would see an
+# orphaned stage, never run it, and happily publish an untested toolchain. Since
+# the copy needs test's filesystem to resolve, and test's CACHEBUST layer can
+# never be served from cache, FTL is rebuilt and retested on every build and a
+# failure there fails this target before it exists.
+#
+# /toolchain-validated holds the CACHEBUST value, so the image also records which
+# CI run validated it.
+FROM build AS publish
+COPY --from=test /toolchain-validated /toolchain-validated

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -244,8 +244,13 @@ ARG GIT_BRANCH="special/CI_development"
 
 # Test compile FTL's development branch, the result is removed from the final container
 # Run the full test suite to ensure that the container is still capable of running the tests
-# Ensure that the TERM environment variable is set for BATS color output
-RUN git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
+# CACHEBUST is fed a per-run value so this layer never comes from cache: it is a
+# validation gate, not a build artifact, and must re-test against current FTL every
+# time (a cache hit here would silently skip building/testing FTL entirely).
+# TERM is set for BATS colour output during the test run.
+ARG CACHEBUST
+RUN echo "Validating toolchain against FTL (build ${CACHEBUST})" \
+    && git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
     && cd FTL \
     && bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON" \
     && readelf -A ./pihole-FTL \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -1,6 +1,3 @@
-FROM alpine:3.24 AS build
-
-ARG TARGETPLATFORM
 ARG readlineversion=8.3
 ARG termcapversion=1.3.1-patched
 ARG nettleversion=3.10.2
@@ -14,7 +11,15 @@ ARG BATS_SUPPORT_VER=v0.3.0
 ARG BATS_ASSERT_VER=v2.2.4
 ARG BATS_FILE_VER=v0.4.0
 
-RUN apk add --no-cache \
+FROM alpine:3.24 AS base
+
+# apk uses a BuildKit cache mount instead of --no-cache so downloaded packages are
+# reused across builds rather than bloating the layer. Intentional tradeoff: without
+# --no-cache the index is no longer force-refreshed each build, so package versions
+# can go stale between cache-mount evictions. Acceptable for a build toolchain pinned
+# to a specific alpine tag.
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add \
         alpine-sdk \
         bash \
         bind-tools \
@@ -53,11 +58,10 @@ RUN apk add --no-cache \
         xxd \
         zip
 
-ENV STATIC=true
-ENV TEST=true
-
 # As of Alpine 3.21 (Dec 2024), we need to patch the termcap library to include
 # the standard headers as well as unistd.h for the write function
+FROM base AS termcap-build
+ARG termcapversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
     && ./configure --enable-static --disable-shared --disable-doc --without-examples \
@@ -68,6 +72,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
     && cd .. \
     && rm -r termcap-${termcapversion}
 
+FROM base AS readline-build
+ARG readlineversion
+COPY --from=termcap-build /usr/local/ /usr/local/
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
     && ./configure --enable-static --disable-shared --disable-install-examples \
@@ -77,6 +84,8 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
+FROM base AS nettle-build
+ARG nettleversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
     && ./configure --enable-static --disable-shared --disable-openssl --disable-mini-gmp -disable-gcov --disable-documentation \
@@ -87,6 +96,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
 # Build static mbedTLS with pthread support
 # Disable AESNI on linux/386 asit would possibly result in an incompatible
 # binary in processors lacking the AESNI and SSE2 instruction sets
+FROM base AS mbedtls-build
+ARG TARGETPLATFORM
+ARG mbedtlsversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz2 | tar -xj \
     && cd mbedtls-${mbedtlsversion} \
     && sed -i '/#define MBEDTLS_THREADING_C/s*^//**g' tf-psa-crypto/include/psa/crypto_config.h \
@@ -114,6 +126,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
 # (386 on a 64-bit kernel, the 32-bit ARM variants on an arm64 runner, riscv64
 # under QEMU) and yields "64-bit mode not compiled in". Runtime CPU-feature
 # dispatch still handles AES-NI etc., so no further per-arch tuning is needed.
+FROM base AS openssl-build
+ARG TARGETPLATFORM
+ARG opensslversion
 RUN case "${TARGETPLATFORM}" in \
         "linux/amd64")   OSSL_TARGET="linux-x86_64"    ;; \
         "linux/386")     OSSL_TARGET="linux-x86"       ;; \
@@ -139,6 +154,8 @@ RUN case "${TARGETPLATFORM}" in \
 
 # Static HTTP/2, HTTP/3 and QUIC libraries. Library-only builds
 # (--enable-lib-only) to drop the apps and their extra dependencies.
+FROM base AS nghttp2-build
+ARG nghttp2version
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nghttp2-${nghttp2version}.tar.gz | tar -xz \
     && cd nghttp2-${nghttp2version} \
     && ./configure --enable-lib-only --enable-static --disable-shared \
@@ -147,6 +164,8 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nghttp2-${nghttp2version}.tar.gz
     && cd .. \
     && rm -r nghttp2-${nghttp2version}
 
+FROM base AS nghttp3-build
+ARG nghttp3version
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nghttp3-${nghttp3version}.tar.gz | tar -xz \
     && cd nghttp3-${nghttp3version} \
     && ./configure --enable-lib-only --enable-static --disable-shared \
@@ -155,8 +174,15 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nghttp3-${nghttp3version}.tar.gz
     && cd .. \
     && rm -r nghttp3-${nghttp3version}
 
-# ngtcp2 after OpenSSL: --with-openssl builds the "ossl" crypto backend
-# (libngtcp2_crypto_ossl) against the static OpenSSL 4.0 above.
+# ngtcp2 needs OpenSSL: --with-openssl builds the "ossl" crypto backend
+# (libngtcp2_crypto_ossl) against the static OpenSSL 4.0 above. nghttp3 is copied
+# in as well: it is not needed for --enable-lib-only, but it was present when
+# these three shared a single stage, so it is kept in scope to keep configure's
+# probe results - and therefore the installed artefacts - identical.
+FROM base AS ngtcp2-build
+ARG ngtcp2version
+COPY --from=openssl-build /usr/local/ /usr/local/
+COPY --from=nghttp3-build /usr/local/ /usr/local/
 RUN curl -sSL https://ftl.pi-hole.net/libraries/ngtcp2-${ngtcp2version}.tar.gz | tar -xz \
     && cd ngtcp2-${ngtcp2version} \
     && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-lib-only --enable-static --disable-shared --with-openssl \
@@ -166,6 +192,7 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/ngtcp2-${ngtcp2version}.tar.gz |
     && rm -r ngtcp2-${ngtcp2version}
 
 # Build static libbacktrace
+FROM base AS libbacktrace-build
 RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
     && cd libbacktrace \
     && ./configure --enable-static --disable-shared \
@@ -173,11 +200,34 @@ RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
     && cd .. \
     && rm -r libbacktrace
 
-# Install bats-core directly into the build image
+# Install bats-core, plus the bats-support/bats-assert/bats-file helper
+# libraries FTL's test suite loads via BATS_LIB_PATH
+FROM base AS bats-build
+ARG BATS_CORE_VER
+ARG BATS_SUPPORT_VER
+ARG BATS_ASSERT_VER
+ARG BATS_FILE_VER
 RUN git clone --depth=1 --single-branch --branch "${BATS_CORE_VER}" https://github.com/bats-core/bats-core.git /bats/bats-core \
   && git clone --depth=1 --single-branch --branch "${BATS_SUPPORT_VER}" https://github.com/bats-core/bats-support /bats/bats-support \
   && git clone --depth=1 --single-branch --branch "${BATS_ASSERT_VER}" https://github.com/bats-core/bats-assert  /bats/bats-assert \
   && git clone --depth=1 --single-branch --branch "${BATS_FILE_VER}" https://github.com/bats-core/bats-file    /bats/bats-file
+
+FROM base AS build
+
+ENV STATIC=true
+ENV TEST=true
+
+COPY --link --from=termcap-build /usr/local/ /usr/local/
+COPY --link --from=readline-build /usr/local/ /usr/local/
+COPY --link --from=nettle-build /usr/local/ /usr/local/
+COPY --link --from=mbedtls-build /usr/local/ /usr/local/
+COPY --link --from=openssl-build /usr/local/ /usr/local/
+COPY --link --from=nghttp2-build /usr/local/ /usr/local/
+COPY --link --from=nghttp3-build /usr/local/ /usr/local/
+COPY --link --from=ngtcp2-build /usr/local/ /usr/local/
+COPY --link --from=libbacktrace-build /usr/local/ /usr/local/
+COPY --link --from=bats-build /bats /bats
+
 ENV BATS=/bats/bats-core/bin/bats
 ENV BATS_LIB_PATH=/bats/
 
@@ -191,7 +241,6 @@ ARG TARGETVARIANT
 ARG CI_ARCH="$TARGETPLATFORM"
 ARG GIT_TAG="test-build"
 ARG GIT_BRANCH="special/CI_development"
-
 
 # Test compile FTL's development branch, the result is removed from the final container
 # Run the full test suite to ensure that the container is still capable of running the tests


### PR DESCRIPTION
## Summary

- **Build, test and publish in a single job.** `build-and-push` is merged into `build-and-test`, so the toolchain is built once and pushed when `DO_DEPLOY` is true, rather than being rebuilt from scratch in a second job just to publish. Nightly, branch and release tagging are unchanged.
- **Multi-stage Dockerfile.** The single build stage is split into isolated per-library stages (termcap, readline, nettle, mbedTLS, openssl, nghttp2, nghttp3, ngtcp2, libbacktrace, bats) derived from a shared `base` and assembled with `COPY --link`, so a version bump to one library only invalidates that stage and its copy layer instead of every layer after it. `apk` uses a BuildKit cache mount instead of `--no-cache`. Multi-stage approach from #162.
- **Never cache the FTL build/test layer.** The test stage clones, builds and tests FTL to prove the toolchain still works. As a plain `RUN` it would be served from cache whenever the toolchain layers are unchanged, silently skipping the test; a per-run `CACHEBUST` build-arg forces just that layer to re-run every build while the toolchain stays cached.
- **Publish a clean image.** A new `publish` stage is what gets pushed, so the test run's leftovers no longer ship. Details below.

## The published image no longer carries test residue

@yubiuser [spotted](https://github.com/pi-hole/docker-base-images/pull/171#issuecomment-4989719391) that publishing `target: test` leaves test state in the final image, and @DL6ER raised the same thing on Mattermost. The full list is a bit longer than either of us had counted:

| Path | What lands there |
| --- | --- |
| `/etc/pihole/` | `gravity.db`, `pihole-FTL.db`, `pihole.toml`, `versions`, test cert/key, `dhcp.leases`, `config_backups/` |
| `/var/log/pihole/` | `FTL.log`, `pihole.log`, `webserver.log` (~10 MB between them) |
| `/etc/dnsmasq.d/` | `01-pihole-tests.conf` **and** `02-trust-anchor.conf` |
| `/var/lib/powerdns/` | `pdns.sqlite3` — the DNSSEC-signed test zones, keys included |
| `/etc/pdns/` | `pdns.conf`, `recursor.conf`, `luadns.lua`, overwritten |
| `/var/www/html/` | `broken_lua.lp`, `broken_lua_2.lp` |
| `/home/pihole/`, `/etc/passwd`+`shadow`+`group` | the `pihole` user `run.sh` creates |
| `/run/pihole`, `/run/pihole-FTL.pid`, `/var/run/pdns-recursor` | runtime state |

Plus `ENV TARGETPLATFORM` from the test stage.

The obvious fix — an `rm -rf` at the end of the test `RUN` — means enumerating every one of those paths and keeping that list in step with FTL's test suite forever. It would also have to be conditional, since DL6ER quite reasonably wants the logs to survive a local run he is debugging.

So instead, `test` is no longer what gets published:

```dockerfile
FROM build AS test
ARG CACHEBUST
RUN echo "Validating toolchain against FTL (build ${CACHEBUST})" \
    && git clone ... && bash build.sh ... && bash test/run.sh \
    && echo "${CACHEBUST}" > /toolchain-validated

FROM build AS publish
COPY --from=test /toolchain-validated /toolchain-validated
```

`publish` is `FROM build`, so it contains the toolchain and nothing else — byte-for-byte the image contents this workflow published before this branch, `ENV` included.

The `COPY` is doing real work, not decoration. A Dockerfile has no way to say "this stage depends on that one", and BuildKit only builds stages the target actually needs — without that line `test` would be an orphan, never run, and we would cheerfully publish an untested toolchain. Because the copy needs `test`'s filesystem to resolve, and `test`'s `CACHEBUST` layer can never come from cache, FTL is rebuilt and retested on every single build and a failure there fails `publish` before it exists.

Two things fall out of this for free:

- Nothing has to be enumerated, so nothing can be forgotten or drift as the test suite grows.
- `docker build --target test` still works and now keeps the **FTL checkout as well as** the logs (the `rm -r FTL` is gone — no point deleting something that is discarded anyway), which is exactly what you want when debugging locally. No flag, no conditional, and no change needed in FTL's `run.sh`.

`/toolchain-validated` holds the `CACHEBUST` value, so the image records which CI run validated it:

```
$ docker run --rm ghcr.io/pi-hole/ftl-build:nightly cat /toolchain-validated
17234567890-1
```

## Notes for reviewers

- **Rebased onto current master**, which brought in OpenSSL 4.0 and the new nghttp2 / nghttp3 / ngtcp2 libraries (#173). Worth knowing: git auto-merged that rebase without reporting a conflict, but the result was wrong — the three new `RUN` blocks ended up stranded inside `openssl-build` and were never copied into `build`, which would have silently dropped all three libraries from the image. They now have their own stages. `ngtcp2-build` takes `COPY --from=openssl-build` for `--with-openssl`, and also `--from=nghttp3-build`: `--enable-lib-only` doesn't need nghttp3, but it *was* in scope when these three shared one stage, so it stays in scope to keep configure's probe results identical.
- **`packages: write` is now held on every run**, not just deploys, because GitHub does not allow expressions in `permissions`. This grants nothing extra in practice: `smoke-tests` only runs on `pull_request` for forks, and a fork's `GITHUB_TOKEN` is read-only regardless. Noted in a comment in the workflow.
- **The `nightly` tag is unchanged** and still published — thanks @yubiuser for catching that FTL's `.devcontainer/devcontainer.json` consumes it.