### PR TITLE
Seed a `ccache` so the FTL validation stops recompiling unchanged units

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -248,7 +248,7 @@ ENV FTL_CMAKE_ARGS="-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_RE
 # small (~28 MB), as the GHA cache is a shared, size-limited resource.
 FROM ftl-validate AS ccache-seed
 ARG GIT_BRANCH="special/CI_development"
-RUN git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
+RUN git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" --single-branch \
     && cd FTL \
     && bash build.sh "${FTL_CMAKE_ARGS}" \
     && cd .. \

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -223,7 +223,40 @@ RUN for lib in termcap readline history nettle hogweed ssl crypto nghttp2 nghttp
         [ -f "/usr/local/lib/lib${lib}.a" ] || { echo "missing lib${lib}.a" >&2; exit 1; }; \
     done
 
-FROM build AS test
+# Both FTL compiles below - the ccache seed and the validation run - have to
+# invoke the compiler identically or ccache never hits, so everything they share
+# is defined here and neither stage can drift away from it.
+FROM build AS ftl-validate
+ENV CCACHE_DIR=/ccache
+ENV CCACHE_MAXSIZE=500M
+ENV FTL_CMAKE_ARGS="-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache"
+
+# Compiling FTL is what the validation below actually costs, and most of it is
+# spent on translation units FTL never touches: sqlite3.c alone is the critical
+# path on every platform (~15 min of a ~29 min riscv64 build under QEMU). This
+# stage compiles FTL once so the validation run can reuse the objects.
+#
+# It is deliberately not fed CACHEBUST, and nothing else expires it either: the
+# layer should be served from the layer cache for as long as it survives there.
+# That cannot mask a toolchain regression, because this stage sits on top of
+# every toolchain layer - a new alpine digest, a different package set or a
+# rebuilt library invalidates it and forces a fresh compile. It does go stale
+# against FTL, which is harmless: changed sources miss and are compiled, and an
+# unchanged source cannot yield a different object from an unchanged compiler.
+#
+# Only /ccache survives; the checkout is dropped so the exported layer stays
+# small (~28 MB), as the GHA cache is a shared, size-limited resource.
+FROM ftl-validate AS ccache-seed
+ARG GIT_BRANCH="special/CI_development"
+RUN git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
+    && cd FTL \
+    && bash build.sh "${FTL_CMAKE_ARGS}" \
+    && cd .. \
+    && rm -rf FTL \
+    && ccache --show-stats \
+    && ccache --zero-stats
+
+FROM ftl-validate AS test
 
 # For FTL test compilation
 ARG TARGETPLATFORM
@@ -249,11 +282,18 @@ ARG GIT_BRANCH="special/CI_development"
 # For local builds, set `--build-arg CACHEBUST=$(date +%s)` to force a rebuild and test run.
 #
 # TERM is set for BATS colour output during the test run.
+#
+# The seeded ccache only ever short-circuits compiling a translation unit that
+# is bit-identical to one already compiled with the same compiler and flags.
+# Everything else - the link, the checksum, arch_test.sh and the full test suite
+# - still runs from scratch on every build.
+COPY --from=ccache-seed /ccache /ccache
 ARG CACHEBUST=local
 RUN echo "Validating toolchain against FTL (build ${CACHEBUST})" \
     && git clone https://github.com/pi-hole/FTL.git --branch "${GIT_BRANCH}" \
     && cd FTL \
-    && bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON" \
+    && bash build.sh "${FTL_CMAKE_ARGS}" \
+    && ccache --show-stats \
     && readelf -A ./pihole-FTL \
     && readelf -l ./pihole-FTL \
     && bash test/arch_test.sh \


### PR DESCRIPTION
Our `test` stage is fed a per-run `CACHEBUST`, so it re-clones and rebuilds FTL on every build. That is deliberate - a cache hit there would silently skip validating the toolchain - but it means the cost never goes away, and it is concentrated in one place. On `linux/riscv64` the whole job takes 29m43s, of which 28m43s is that single layer; every other layer is served from cache. Inside it, `src/database/sqlite3.c` alone accounts for ~15 min under QEMU, and it is the critical path on *every* platform, ~40% even on `linux/amd64`.

Most of that work is wasted. The units that dominate the compile are the vendored ones - sqlite3, dnsmasq, lua, tre-regex, civetweb - and they change every few months at most, while we recompile them from scratch on every single run.

This adds a `ccache-seed` stage that compiles FTL once and keeps only the resulting `/ccache` (~28 MB). The `test` stage copies it in and builds with `-DCMAKE_C_COMPILER_LAUNCHER=ccache`, so only units that actually changed are compiled. A new `ftl-validate` stage holds the flags both stages share, as they have to invoke the compiler identically or nothing ever hits.

The seed is deliberately not fed `CACHEBUST`, and nothing else expires it either. That cannot mask a toolchain regression, as the stage sits on top of every toolchain layer: a new alpine digest, a different package set or a rebuilt library invalidates it and forces a fresh compile. It does go stale against FTL, which is harmless - changed sources miss and are compiled, and an unchanged source cannot yield a different object from an unchanged compiler. We considered expiring the seed on a timer and dropped it: we rebuild these images far less often than any sensible interval, so the seed would be rebuilt on nearly every run and we would pay for two compiles instead of one.

Nothing here reaches the published image. `publish` still derives from `build`, and `ccache` is installed in `ftl-validate`, below it, so the toolchain we ship is byte-for-byte what it was.

Measured locally on `linux/amd64`:

```
seed stage        205 / 205 misses   compile+link 46s
validation stage  204 / 205 hits     compile+link 7.6s
```

The one miss is `version.c`, the only generated unit - it picks up `CI_ARCH` and `GIT_TAG`, which the seed does not set. A new `CACHEBUST` leaves the seed cached and re-runs the validation in full, and changing the Dockerfile rebuilds both. The full test suite passes either way.

Two things worth knowing before this is merged:

- The seed adds ~28 MB per platform, so ~171 MB across the six. Our Actions cache currently sits at 10.5 GB against a 10 GB limit with 494 entries, i.e., GitHub is already evicting from it. That is a pre-existing problem rather than one this creates, but it is worth some housekeeping either way - if the seed gets evicted it simply rebuilds.
- The link and the FTL test suite are untouched by this and remain the floor of what the riscv64 job costs.

The same idea was tried on the FTL side first, where CI has no build cache at all and runs on every push. There the riscv64 job went from 24 min to 10 min, with the compile step itself dropping from 895 s to 17 s - see pi-hole/FTL#2995.
