### PR TITLE
Add `ccache` to the toolchain

### DIFF
--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
         bash \
         bind-tools \
         binutils \
+        ccache \
         clang \
         cmake \
         curl \


### PR DESCRIPTION
This adds `ccache` to the toolchain, and nothing else. One line.

FTL's CI starts every job from a fresh checkout on a fresh runner, so cmake has no build tree left to compare timestamps against and recompiles all 207 translation units on every run, even when a commit touches a single file. Locally we never notice this, as our build tree persists. `ccache` is keyed on *content* - a hash of the source, the headers it pulls in, the compiler and the flags - rather than on mtimes inside a build tree, so it survives the fresh clone and only the units that actually changed get compiled.

We are trying that in pi-hole/FTL#2995. It takes the `linux/riscv64` job from 24 to 10 minutes, with the compile step itself dropping from 895 to 17 seconds, and it helps every other platform by a minute or two as well. That PR installs `ccache` with its own `apk add` in `.github/Dockerfile`, which was the right way to *measure* the idea without cutting an image release first, but it is the wrong place to keep it - the toolchain belongs here. Once this is merged and tagged, FTL switches to the new tag and drops that `apk add` again.

Worth being explicit about the blast radius, since this image is used by more than that one workflow: adding the package changes nothing on its own. `ccache` only ever does anything if a build opts in by passing `-DCMAKE_C_COMPILER_LAUNCHER=ccache`, so every consumer of this image keeps compiling exactly as it does today until it chooses otherwise. The cost is 1.2 MB installed.

Note that this invalidates the `base` layer, so CI here rebuilds all six platforms from scratch for this PR.

There is a second, larger change waiting in #182 that uses `ccache` inside our own FTL validation stage. That one is unrelated to this PR beyond sharing the dependency, and it stays a draft for now.
